### PR TITLE
Reduce number of reallocations

### DIFF
--- a/src/dkg/complaint.rs
+++ b/src/dkg/complaint.rs
@@ -118,7 +118,7 @@ impl<C: CipherSuite> Complaint<C> {
 
     /// Serialize this [`Complaint`] to a vector of bytes.
     pub fn to_bytes(&self) -> FrostResult<C, Vec<u8>> {
-        let mut bytes = Vec::new();
+        let mut bytes = Vec::with_capacity(self.compressed_size());
 
         self.serialize_compressed(&mut bytes)
             .map_err(|_| Error::SerializationError)?;
@@ -146,7 +146,7 @@ pub struct ComplaintProof<C: CipherSuite> {
 impl<C: CipherSuite> ComplaintProof<C> {
     /// Serialize this [`ComplaintProof`] to a vector of bytes.
     pub fn to_bytes(&self) -> FrostResult<C, Vec<u8>> {
-        let mut bytes = Vec::new();
+        let mut bytes = Vec::with_capacity(self.compressed_size());
 
         self.serialize_compressed(&mut bytes)
             .map_err(|_| Error::SerializationError)?;

--- a/src/dkg/key_generation.rs
+++ b/src/dkg/key_generation.rs
@@ -521,7 +521,8 @@ pub struct DKGParticipantList<C: CipherSuite> {
 impl<C: CipherSuite> DistributedKeyGeneration<RoundOne, C> {
     /// Serialize this [`DistributedKeyGeneration<RoundOne, _>`] to a vector of bytes.
     pub fn to_bytes(&self) -> FrostResult<C, Vec<u8>> {
-        let mut bytes = Vec::new();
+        let mut bytes =
+            Vec::with_capacity(self.state.compressed_size() + self.data.compressed_size());
 
         self.state
             .serialize_compressed(&mut bytes)
@@ -741,7 +742,7 @@ impl<C: CipherSuite> DistributedKeyGeneration<RoundOne, C> {
                 SecretShare::<C>::evaluate_polynomial(my_index, &p.index, my_coefficients.unwrap());
 
             let dh_key = p.dh_public_key.key * dh_private_key.0;
-            let mut dh_key_bytes = Vec::new();
+            let mut dh_key_bytes = Vec::with_capacity(dh_key.compressed_size());
             dh_key
                 .serialize_compressed(&mut dh_key_bytes)
                 .map_err(|_| Error::CompressionError)?;
@@ -820,7 +821,7 @@ impl<C: CipherSuite> DistributedKeyGeneration<RoundOne, C> {
             for pk in self.state.their_dh_public_keys.iter() {
                 if pk.0 == encrypted_share.sender_index {
                     let dh_shared_key = *pk.1 * self.state.dh_private_key.0;
-                    let mut dh_key_bytes = Vec::new();
+                    let mut dh_key_bytes = Vec::with_capacity(dh_shared_key.compressed_size());
                     dh_shared_key
                         .serialize_compressed(&mut dh_key_bytes)
                         .map_err(|_| Error::CompressionError)?;
@@ -879,7 +880,8 @@ impl<C: CipherSuite> DistributedKeyGeneration<RoundOne, C> {
 impl<C: CipherSuite> DistributedKeyGeneration<RoundTwo, C> {
     /// Serialize this [`DistributedKeyGeneration<RoundTwo, _>`] to a vector of bytes.
     pub fn to_bytes(&self) -> FrostResult<C, Vec<u8>> {
-        let mut bytes = Vec::new();
+        let mut bytes =
+            Vec::with_capacity(self.state.compressed_size() + self.data.compressed_size());
 
         self.state
             .serialize_compressed(&mut bytes)
@@ -929,7 +931,7 @@ impl<C: CipherSuite> DistributedKeyGeneration<RoundTwo, C> {
             Error::Custom("Could not retrieve participant's secret shares".to_string())
         })?;
 
-        let mut index_vector: Vec<u32> = Vec::new();
+        let mut index_vector = Vec::with_capacity(my_secret_shares.len());
 
         for share in my_secret_shares.iter() {
             index_vector.push(share.sender_index);
@@ -961,7 +963,8 @@ impl<C: CipherSuite> DistributedKeyGeneration<RoundTwo, C> {
     /// my_commitment is needed for now, but won't be when the distinction
     /// dealers/signers is implemented.
     pub(crate) fn calculate_group_key(&self) -> FrostResult<C, GroupVerifyingKey<C>> {
-        let mut index_vector: Vec<u32> = Vec::new();
+        let mut index_vector =
+            Vec::with_capacity(self.state.their_commitments.as_ref().unwrap().len());
 
         for commitment in self.state.their_commitments.as_ref().unwrap().iter() {
             index_vector.push(commitment.index);
@@ -1025,7 +1028,7 @@ impl<C: CipherSuite> DistributedKeyGeneration<RoundTwo, C> {
             return complaint.maker_index;
         }
 
-        let mut dh_key_bytes = Vec::new();
+        let mut dh_key_bytes = Vec::with_capacity(complaint.dh_shared_key.compressed_size());
         if complaint
             .dh_shared_key
             .serialize_compressed(&mut dh_key_bytes)
@@ -1078,7 +1081,7 @@ mod test {
 
     #[test]
     fn secret_share_from_one_coefficients() {
-        let mut coeffs: Vec<Fr> = Vec::new();
+        let mut coeffs: Vec<Fr> = Vec::with_capacity(5);
 
         for _ in 0..5 {
             coeffs.push(Fr::ONE);
@@ -1105,7 +1108,7 @@ mod test {
 
     #[test]
     fn secret_share_participant_index_zero() {
-        let mut coeffs: Vec<Fr> = Vec::new();
+        let mut coeffs: Vec<Fr> = Vec::with_capacity(5);
 
         for _ in 0..5 {
             coeffs.push(Fr::ONE);
@@ -2148,7 +2151,7 @@ mod test {
             // Wrong encrypted share
             {
                 let dh_key = p1.dh_public_key.key * dh_sk1.0;
-                let mut dh_key_bytes = Vec::new();
+                let mut dh_key_bytes = Vec::with_capacity(dh_key.compressed_size());
                 dh_key.serialize_compressed(&mut dh_key_bytes).unwrap();
                 let wrong_encrypted_secret_share = encrypt_share(
                     &SecretShare::<Secp256k1Sha256> {

--- a/src/dkg/nizkpok.rs
+++ b/src/dkg/nizkpok.rs
@@ -37,7 +37,7 @@ pub struct NizkPokOfSecretKey<C: CipherSuite> {
 impl<C: CipherSuite> NizkPokOfSecretKey<C> {
     /// Serialize this [`NizkPokOfSecretKey`] to a vector of bytes.
     pub fn to_bytes(&self) -> FrostResult<C, Vec<u8>> {
-        let mut bytes = Vec::new();
+        let mut bytes = Vec::with_capacity(self.compressed_size());
 
         self.serialize_compressed(&mut bytes)
             .map_err(|_| Error::SerializationError)?;
@@ -121,7 +121,7 @@ mod test {
                 s: Fr::rand(&mut rng),
                 r: Fr::rand(&mut rng),
             };
-            let mut bytes = Vec::new();
+            let mut bytes = Vec::with_capacity(nizk.compressed_size());
             nizk.serialize_compressed(&mut bytes).unwrap();
             assert_eq!(
                 nizk,

--- a/src/dkg/participant.rs
+++ b/src/dkg/participant.rs
@@ -271,7 +271,7 @@ impl<C: CipherSuite> Participant<C> {
 
     /// Serialize this [`Participant`] to a vector of bytes.
     pub fn to_bytes(&self) -> FrostResult<C, Vec<u8>> {
-        let mut bytes = Vec::new();
+        let mut bytes = Vec::with_capacity(self.compressed_size());
 
         self.serialize_compressed(&mut bytes)
             .map_err(|_| Error::SerializationError)?;

--- a/src/dkg/secret_share.rs
+++ b/src/dkg/secret_share.rs
@@ -33,7 +33,7 @@ pub struct Coefficients<C: CipherSuite>(pub(crate) Vec<Scalar<C>>);
 impl<C: CipherSuite> Coefficients<C> {
     /// Serialize this `coefficients` to a vector of bytes.
     pub fn to_bytes(&self) -> FrostResult<C, Vec<u8>> {
-        let mut bytes = Vec::new();
+        let mut bytes = Vec::with_capacity(self.compressed_size());
 
         self.serialize_compressed(&mut bytes)
             .map_err(|_| Error::SerializationError)?;
@@ -75,7 +75,7 @@ impl<C: CipherSuite> Drop for SecretShare<C> {
 impl<C: CipherSuite> SecretShare<C> {
     /// Serialize this [`SecretShare`] to a vector of bytes.
     pub fn to_bytes(&self) -> FrostResult<C, Vec<u8>> {
-        let mut bytes = Vec::new();
+        let mut bytes = Vec::with_capacity(self.compressed_size());
 
         self.serialize_compressed(&mut bytes)
             .map_err(|_| Error::SerializationError)?;
@@ -178,7 +178,7 @@ impl<C: CipherSuite> EncryptedSecretShare<C> {
 
     /// Serialize this [`EncryptedSecretShare`] to a vector of bytes.
     pub fn to_bytes(&self) -> FrostResult<C, Vec<u8>> {
-        let mut bytes = Vec::new();
+        let mut bytes = Vec::with_capacity(self.compressed_size());
 
         self.serialize_compressed(&mut bytes)
             .map_err(|_| Error::SerializationError)?;
@@ -205,7 +205,7 @@ pub struct VerifiableSecretSharingCommitment<C: CipherSuite> {
 impl<C: CipherSuite> VerifiableSecretSharingCommitment<C> {
     /// Serialize this [`VerifiableSecretSharingCommitment`] to a vector of bytes.
     pub fn to_bytes(&self) -> FrostResult<C, Vec<u8>> {
-        let mut bytes = Vec::new();
+        let mut bytes = Vec::with_capacity(self.compressed_size());
 
         self.serialize_compressed(&mut bytes)
             .map_err(|_| Error::SerializationError)?;
@@ -263,7 +263,7 @@ pub(crate) fn encrypt_share<C: CipherSuite>(
     let cipher = Aes128::new(final_aes_key);
     let mut cipher = Aes128Ctr::from_block_cipher(cipher, nonce);
 
-    let mut share_bytes = Vec::new();
+    let mut share_bytes = Vec::with_capacity(share.polynomial_evaluation.compressed_size());
     share
         .polynomial_evaluation
         .serialize_compressed(&mut share_bytes)
@@ -326,7 +326,7 @@ mod test {
                 receiver_index: rng.next_u32(),
                 polynomial_evaluation: Fr::rand(&mut rng),
             };
-            let mut bytes = Vec::new();
+            let mut bytes = Vec::with_capacity(secret_share.compressed_size());
             secret_share.serialize_compressed(&mut bytes).unwrap();
             assert_eq!(
                 secret_share,
@@ -345,7 +345,7 @@ mod test {
                 nonce,
                 encrypted_polynomial_evaluation,
             );
-            let mut bytes = Vec::new();
+            let mut bytes = Vec::with_capacity(encrypted_secret_share.compressed_size());
             encrypted_secret_share
                 .serialize_compressed(&mut bytes)
                 .unwrap();

--- a/src/keys.rs
+++ b/src/keys.rs
@@ -24,7 +24,7 @@ pub struct DiffieHellmanPrivateKey<C: CipherSuite>(pub(crate) <C::G as Group>::S
 impl<C: CipherSuite> DiffieHellmanPrivateKey<C> {
     /// Serialize this [`DiffieHellmanPrivateKey`] to a vector of bytes.
     pub fn to_bytes(&self) -> FrostResult<C, Vec<u8>> {
-        let mut bytes = Vec::new();
+        let mut bytes = Vec::with_capacity(self.compressed_size());
 
         self.serialize_compressed(&mut bytes)
             .map_err(|_| Error::SerializationError)?;
@@ -62,7 +62,7 @@ impl<C: CipherSuite> DiffieHellmanPublicKey<C> {
 
     /// Serialize this [`DiffieHellmanPublicKey`] to a vector of bytes.
     pub fn to_bytes(&self) -> FrostResult<C, Vec<u8>> {
-        let mut bytes = Vec::new();
+        let mut bytes = Vec::with_capacity(self.compressed_size());
 
         self.serialize_compressed(&mut bytes)
             .map_err(|_| Error::SerializationError)?;
@@ -99,7 +99,7 @@ pub struct IndividualVerifyingKey<C: CipherSuite> {
 impl<C: CipherSuite> IndividualVerifyingKey<C> {
     /// Serialize this [`IndividualVerifyingKey`] to a vector of bytes.
     pub fn to_bytes(&self) -> FrostResult<C, Vec<u8>> {
-        let mut bytes = Vec::new();
+        let mut bytes = Vec::with_capacity(self.compressed_size());
 
         self.serialize_compressed(&mut bytes)
             .map_err(|_| Error::SerializationError)?;
@@ -138,7 +138,7 @@ impl<C: CipherSuite> IndividualVerifyingKey<C> {
         let mut rhs: C::G = <C as CipherSuite>::G::zero();
         let term: <C::G as Group>::ScalarField = self.index.into();
 
-        let mut index_vector: Vec<u32> = Vec::new();
+        let mut index_vector = Vec::with_capacity(commitments.len());
         for commitment in commitments.iter() {
             index_vector.push(commitment.index);
         }
@@ -194,7 +194,7 @@ impl<C: CipherSuite> IndividualVerifyingKey<C> {
         let mut share: C::G = <C as CipherSuite>::G::zero();
         let term: <C::G as Group>::ScalarField = participant_index.into();
 
-        let mut index_vector: Vec<u32> = Vec::new();
+        let mut index_vector = Vec::with_capacity(commitments.len());
         for commitment in commitments.iter() {
             index_vector.push(commitment.index);
         }
@@ -233,7 +233,7 @@ pub struct IndividualSigningKey<C: CipherSuite> {
 impl<C: CipherSuite> IndividualSigningKey<C> {
     /// Serialize this [`IndividualSigningKey`] to a vector of bytes.
     pub fn to_bytes(&self) -> FrostResult<C, Vec<u8>> {
-        let mut bytes = Vec::new();
+        let mut bytes = Vec::with_capacity(self.compressed_size());
 
         self.serialize_compressed(&mut bytes)
             .map_err(|_| Error::SerializationError)?;
@@ -310,7 +310,7 @@ impl<C: CipherSuite> GroupVerifyingKey<C> {
 
     /// Serialize this [`GroupVerifyingKey`] to a vector of bytes.
     pub fn to_bytes(&self) -> FrostResult<C, Vec<u8>> {
-        let mut bytes = Vec::new();
+        let mut bytes = Vec::with_capacity(self.compressed_size());
 
         self.serialize_compressed(&mut bytes)
             .map_err(|_| Error::SerializationError)?;

--- a/src/parameters.rs
+++ b/src/parameters.rs
@@ -40,7 +40,7 @@ impl<C: CipherSuite> ThresholdParameters<C> {
 
     /// Serialize this [`ThresholdParameters`] to a vector of bytes.
     pub fn to_bytes(&self) -> FrostResult<C, Vec<u8>> {
-        let mut bytes = Vec::new();
+        let mut bytes = Vec::with_capacity(self.compressed_size());
 
         self.serialize_compressed(&mut bytes)
             .map_err(|_| Error::SerializationError)?;

--- a/src/sign/precomputation.rs
+++ b/src/sign/precomputation.rs
@@ -115,7 +115,7 @@ pub struct CommitmentShare<C: CipherSuite> {
 impl<C: CipherSuite> CommitmentShare<C> {
     /// Serialize this [`CommitmentShare`] to a vector of bytes.
     pub fn to_bytes(&self) -> FrostResult<C, Vec<u8>> {
-        let mut bytes = Vec::new();
+        let mut bytes = Vec::with_capacity(self.compressed_size());
 
         self.serialize_compressed(&mut bytes)
             .map_err(|_| Error::SerializationError)?;
@@ -160,7 +160,7 @@ pub struct SecretCommitmentShareList<C: CipherSuite> {
 impl<C: CipherSuite> SecretCommitmentShareList<C> {
     /// Serialize this [`SecretCommitmentShareList`] to a vector of bytes.
     pub fn to_bytes(&self) -> FrostResult<C, Vec<u8>> {
-        let mut bytes = Vec::new();
+        let mut bytes = Vec::with_capacity(self.compressed_size());
 
         self.serialize_compressed(&mut bytes)
             .map_err(|_| Error::SerializationError)?;
@@ -190,7 +190,7 @@ pub struct PublicCommitmentShareList<C: CipherSuite> {
 impl<C: CipherSuite> PublicCommitmentShareList<C> {
     /// Serialize this [`PublicCommitmentShareList`] to a vector of bytes.
     pub fn to_bytes(&self) -> FrostResult<C, Vec<u8>> {
-        let mut bytes = Vec::new();
+        let mut bytes = Vec::with_capacity(self.compressed_size());
 
         self.serialize_compressed(&mut bytes)
             .map_err(|_| Error::SerializationError)?;
@@ -305,7 +305,7 @@ mod test {
             let secret = Fr::rand(&mut rng);
             let commit = Projective::generator().mul(secret);
             let commitment = Commitment::<Secp256k1Sha256> { secret, commit };
-            let mut bytes = Vec::new();
+            let mut bytes = Vec::with_capacity(commitment.compressed_size());
 
             commitment.serialize_compressed(&mut bytes).unwrap();
             assert_eq!(
@@ -320,7 +320,7 @@ mod test {
             let binding = Commitment::<Secp256k1Sha256> { secret, commit };
             let hiding = binding.clone();
             let commitment_share = CommitmentShare { binding, hiding };
-            let mut bytes = Vec::new();
+            let mut bytes = Vec::with_capacity(commitment_share.compressed_size());
 
             commitment_share.serialize_compressed(&mut bytes).unwrap();
             assert_eq!(

--- a/src/sign/signature.rs
+++ b/src/sign/signature.rs
@@ -64,7 +64,7 @@ pub struct PartialThresholdSignature<C: CipherSuite> {
 impl<C: CipherSuite> PartialThresholdSignature<C> {
     /// Serialize this [`PartialThresholdSignature`] to a vector of bytes.
     pub fn to_bytes(&self) -> FrostResult<C, Vec<u8>> {
-        let mut bytes = Vec::new();
+        let mut bytes = Vec::with_capacity(self.compressed_size());
 
         self.serialize_compressed(&mut bytes)
             .map_err(|_| Error::SerializationError)?;
@@ -88,7 +88,7 @@ pub struct ThresholdSignature<C: CipherSuite> {
 impl<C: CipherSuite> ThresholdSignature<C> {
     /// Serialize this [`ThresholdSignature`] to a vector of bytes.
     pub fn to_bytes(&self) -> FrostResult<C, Vec<u8>> {
-        let mut bytes = Vec::new();
+        let mut bytes = Vec::with_capacity(self.compressed_size());
 
         self.serialize_compressed(&mut bytes)
             .map_err(|_| Error::SerializationError)?;
@@ -293,7 +293,9 @@ pub(crate) fn compute_challenge<C: CipherSuite>(
     group_key: &GroupVerifyingKey<C>,
     message_hash: &[u8],
 ) -> FrostResult<C, Scalar<C>> {
-    let mut challenge_input = Vec::new();
+    let mut challenge_input = Vec::with_capacity(
+        group_commitment.compressed_size() + group_key.compressed_size() + message_hash.len(),
+    );
     group_commitment
         .serialize_compressed(&mut challenge_input)
         .map_err(|_| Error::CompressionError)?;
@@ -531,7 +533,7 @@ impl<C: CipherSuite> SignatureAggregator<C, Initial<'_>> {
     /// A sorted [`Vec`] of unique [`Signer`]s who have yet to contribute their
     /// partial signatures.
     pub fn get_remaining_signers(&self) -> Vec<Signer<C>> {
-        let mut remaining_signers: Vec<Signer<C>> = Vec::new();
+        let mut remaining_signers = Vec::with_capacity(self.state.signers.len());
 
         for signer in self.state.signers.iter() {
             if self
@@ -869,7 +871,7 @@ mod test {
             let mut signers_states_1 = Vec::<Dkg<_>>::new();
             let mut signers_states_2 = Vec::<Dkg<_>>::new();
 
-            let mut dealers = Vec::new();
+            let mut dealers = Vec::with_capacity(n1 as usize);
             let mut dealers_encrypted_secret_shares_for_signers: Vec<
                 Vec<EncryptedSecretShare<Secp256k1Sha256>>,
             > = (0..n1).map(|_| Vec::new()).collect();


### PR DESCRIPTION
# Description

Pre-allocate sufficient amounts when creating new vectors, most of the time relying on the `compressed_size()` method from the `CanonicalSerialize` trait.

Mostly useful for `to_bytes` methods. Some vector initializations are purposedly left untouched, either because they are within unit tests or because they deal with malicious participants which, we hope at least, wouldn't require more than 1 allocation in the worst case (i.e. at most 4 malicious participants at once).

## PR Checklist:

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added or updated tests that comprehensively prove my change is effective or that my feature works
