### PR TITLE
Encoding trait and code duplication removal

### DIFF
--- a/src/dkg/complaint.rs
+++ b/src/dkg/complaint.rs
@@ -1,6 +1,7 @@
 //! The complaint module for handling disputes during an ICE-FROST
 //! Distributed Key Generation session.
 
+use crate::serialization::impl_serialization_traits;
 use crate::utils::{Scalar, Vec};
 use crate::{Error, FrostResult};
 
@@ -28,6 +29,8 @@ pub struct Complaint<C: CipherSuite> {
     /// The complaint proof.
     pub proof: ComplaintProof<C>,
 }
+
+impl_serialization_traits!(Complaint<CipherSuite>);
 
 impl<C: CipherSuite> Complaint<C> {
     pub(crate) fn new(
@@ -115,21 +118,6 @@ impl<C: CipherSuite> Complaint<C> {
 
         Ok(())
     }
-
-    /// Serialize this [`Complaint`] to a vector of bytes.
-    pub fn to_bytes(&self) -> FrostResult<C, Vec<u8>> {
-        let mut bytes = Vec::with_capacity(self.compressed_size());
-
-        self.serialize_compressed(&mut bytes)
-            .map_err(|_| Error::SerializationError)?;
-
-        Ok(bytes)
-    }
-
-    /// Attempt to deserialize a [`Complaint`] from a vector of bytes.
-    pub fn from_bytes(bytes: &[u8]) -> FrostResult<C, Self> {
-        Self::deserialize_compressed(bytes).map_err(|_| Error::DeserializationError)
-    }
 }
 
 /// A proof that a generated complaint is valid.
@@ -143,19 +131,4 @@ pub struct ComplaintProof<C: CipherSuite> {
     pub z: Scalar<C>,
 }
 
-impl<C: CipherSuite> ComplaintProof<C> {
-    /// Serialize this [`ComplaintProof`] to a vector of bytes.
-    pub fn to_bytes(&self) -> FrostResult<C, Vec<u8>> {
-        let mut bytes = Vec::with_capacity(self.compressed_size());
-
-        self.serialize_compressed(&mut bytes)
-            .map_err(|_| Error::SerializationError)?;
-
-        Ok(bytes)
-    }
-
-    /// Attempt to deserialize a [`ComplaintProof`] from a vector of bytes.
-    pub fn from_bytes(bytes: &[u8]) -> FrostResult<C, Self> {
-        Self::deserialize_compressed(bytes).map_err(|_| Error::DeserializationError)
-    }
-}
+impl_serialization_traits!(ComplaintProof<CipherSuite>);

--- a/src/dkg/key_generation.rs
+++ b/src/dkg/key_generation.rs
@@ -490,6 +490,7 @@ use crate::keys::{
     DiffieHellmanPrivateKey, DiffieHellmanPublicKey, GroupVerifyingKey, IndividualSigningKey,
 };
 use crate::parameters::ThresholdParameters;
+use crate::serialization::impl_serialization_traits;
 use crate::{Error, FrostResult};
 
 use crate::utils::calculate_lagrange_coefficients;
@@ -1076,6 +1077,7 @@ mod test {
     use crate::dkg::{ComplaintProof, NizkPokOfSecretKey};
     use crate::keys::IndividualVerifyingKey;
     use crate::testing::Secp256k1Sha256;
+    use crate::{FromBytes, ToBytes};
 
     use ark_ec::Group;
     use ark_ff::UniformRand;

--- a/src/dkg/nizkpok.rs
+++ b/src/dkg/nizkpok.rs
@@ -6,6 +6,7 @@ use ark_ff::UniformRand;
 use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
 
 use crate::ciphersuite::CipherSuite;
+use crate::serialization::impl_serialization_traits;
 use crate::utils::{Scalar, Vec};
 use crate::{Error, FrostResult};
 
@@ -34,22 +35,9 @@ pub struct NizkPokOfSecretKey<C: CipherSuite> {
     r: Scalar<C>,
 }
 
+impl_serialization_traits!(NizkPokOfSecretKey<CipherSuite>);
+
 impl<C: CipherSuite> NizkPokOfSecretKey<C> {
-    /// Serialize this [`NizkPokOfSecretKey`] to a vector of bytes.
-    pub fn to_bytes(&self) -> FrostResult<C, Vec<u8>> {
-        let mut bytes = Vec::with_capacity(self.compressed_size());
-
-        self.serialize_compressed(&mut bytes)
-            .map_err(|_| Error::SerializationError)?;
-
-        Ok(bytes)
-    }
-
-    /// Attempt to deserialize a [`NizkPokOfSecretKey`] from a vector of bytes.
-    pub fn from_bytes(bytes: &[u8]) -> FrostResult<C, Self> {
-        Self::deserialize_compressed(bytes).map_err(|_| Error::DeserializationError)
-    }
-
     /// Prove knowledge of a secret key.
     pub fn prove(
         index: u32,

--- a/src/dkg/participant.rs
+++ b/src/dkg/participant.rs
@@ -18,6 +18,7 @@ use crate::dkg::{
 };
 use crate::keys::{DiffieHellmanPrivateKey, DiffieHellmanPublicKey, IndividualSigningKey};
 use crate::parameters::ThresholdParameters;
+use crate::serialization::impl_serialization_traits;
 use crate::{Error, FrostResult};
 
 use crate::utils::{Scalar, Vec};
@@ -44,6 +45,8 @@ pub struct Participant<C: CipherSuite> {
     /// It is computed similarly to the proof_of_secret_key.
     pub proof_of_dh_private_key: NizkPokOfSecretKey<C>,
 }
+
+impl_serialization_traits!(Participant<CipherSuite>);
 
 impl<C: CipherSuite> Participant<C> {
     /// Construct a new dealer for the distributed key generation protocol,
@@ -267,21 +270,6 @@ impl<C: CipherSuite> Participant<C> {
             .clone();
 
         Ok((dealer, encrypted_shares, participant_lists))
-    }
-
-    /// Serialize this [`Participant`] to a vector of bytes.
-    pub fn to_bytes(&self) -> FrostResult<C, Vec<u8>> {
-        let mut bytes = Vec::with_capacity(self.compressed_size());
-
-        self.serialize_compressed(&mut bytes)
-            .map_err(|_| Error::SerializationError)?;
-
-        Ok(bytes)
-    }
-
-    /// Attempt to deserialize a [`Participant`] from a vector of bytes.
-    pub fn from_bytes(bytes: &[u8]) -> FrostResult<C, Self> {
-        Self::deserialize_compressed(bytes).map_err(|_| Error::DeserializationError)
     }
 
     /// Retrieve \\( \alpha_{i0} * B \\), where \\( B \\) is the prime-order basepoint.

--- a/src/dkg/secret_share.rs
+++ b/src/dkg/secret_share.rs
@@ -7,6 +7,7 @@
 
 use core::marker::PhantomData;
 
+use crate::serialization::impl_serialization_traits;
 use crate::utils::{Scalar, ToString, Vec};
 use crate::{Error, FrostResult};
 
@@ -30,22 +31,7 @@ use zeroize::Zeroize;
 #[derive(Debug, Clone, CanonicalSerialize, CanonicalDeserialize, Zeroize)]
 pub struct Coefficients<C: CipherSuite>(pub(crate) Vec<Scalar<C>>);
 
-impl<C: CipherSuite> Coefficients<C> {
-    /// Serialize this `coefficients` to a vector of bytes.
-    pub fn to_bytes(&self) -> FrostResult<C, Vec<u8>> {
-        let mut bytes = Vec::with_capacity(self.compressed_size());
-
-        self.serialize_compressed(&mut bytes)
-            .map_err(|_| Error::SerializationError)?;
-
-        Ok(bytes)
-    }
-
-    /// Attempt to deserialize a `coefficients` from a vector of bytes.
-    pub fn from_bytes(bytes: &[u8]) -> FrostResult<C, Self> {
-        Self::deserialize_compressed(bytes).map_err(|_| Error::DeserializationError)
-    }
-}
+impl_serialization_traits!(Coefficients<CipherSuite>);
 
 impl<C: CipherSuite> Drop for Coefficients<C> {
     fn drop(&mut self) {
@@ -66,6 +52,8 @@ pub struct SecretShare<C: CipherSuite> {
     pub(crate) polynomial_evaluation: Scalar<C>,
 }
 
+impl_serialization_traits!(SecretShare<CipherSuite>);
+
 impl<C: CipherSuite> Drop for SecretShare<C> {
     fn drop(&mut self) {
         self.zeroize();
@@ -73,21 +61,6 @@ impl<C: CipherSuite> Drop for SecretShare<C> {
 }
 
 impl<C: CipherSuite> SecretShare<C> {
-    /// Serialize this [`SecretShare`] to a vector of bytes.
-    pub fn to_bytes(&self) -> FrostResult<C, Vec<u8>> {
-        let mut bytes = Vec::with_capacity(self.compressed_size());
-
-        self.serialize_compressed(&mut bytes)
-            .map_err(|_| Error::SerializationError)?;
-
-        Ok(bytes)
-    }
-
-    /// Attempt to deserialize a [`SecretShare`] from a vector of bytes.
-    pub fn from_bytes(bytes: &[u8]) -> FrostResult<C, Self> {
-        Self::deserialize_compressed(bytes).map_err(|_| Error::DeserializationError)
-    }
-
     /// Evaluate the polynomial, `f(x)` for the secret coefficients at the value of `x` .
     pub(crate) fn evaluate_polynomial(
         sender_index: &u32,
@@ -153,6 +126,8 @@ pub struct EncryptedSecretShare<C: CipherSuite> {
     _phantom: PhantomData<C>,
 }
 
+impl_serialization_traits!(EncryptedSecretShare<CipherSuite>);
+
 impl<C: CipherSuite> Drop for EncryptedSecretShare<C> {
     fn drop(&mut self) {
         self.zeroize();
@@ -175,21 +150,6 @@ impl<C: CipherSuite> EncryptedSecretShare<C> {
             _phantom: PhantomData,
         }
     }
-
-    /// Serialize this [`EncryptedSecretShare`] to a vector of bytes.
-    pub fn to_bytes(&self) -> FrostResult<C, Vec<u8>> {
-        let mut bytes = Vec::with_capacity(self.compressed_size());
-
-        self.serialize_compressed(&mut bytes)
-            .map_err(|_| Error::SerializationError)?;
-
-        Ok(bytes)
-    }
-
-    /// Attempt to deserialize a [`EncryptedSecretShare`] from a vector of bytes.
-    pub fn from_bytes(bytes: &[u8]) -> FrostResult<C, Self> {
-        Self::deserialize_compressed(bytes).map_err(|_| Error::DeserializationError)
-    }
 }
 
 /// A commitment to a participant's secret polynomial coefficients for Feldman's
@@ -202,22 +162,9 @@ pub struct VerifiableSecretSharingCommitment<C: CipherSuite> {
     pub points: Vec<C::G>,
 }
 
+impl_serialization_traits!(VerifiableSecretSharingCommitment<CipherSuite>);
+
 impl<C: CipherSuite> VerifiableSecretSharingCommitment<C> {
-    /// Serialize this [`VerifiableSecretSharingCommitment`] to a vector of bytes.
-    pub fn to_bytes(&self) -> FrostResult<C, Vec<u8>> {
-        let mut bytes = Vec::with_capacity(self.compressed_size());
-
-        self.serialize_compressed(&mut bytes)
-            .map_err(|_| Error::SerializationError)?;
-
-        Ok(bytes)
-    }
-
-    /// Attempt to deserialize a [`VerifiableSecretSharingCommitment`] from a vector of bytes.
-    pub fn from_bytes(bytes: &[u8]) -> FrostResult<C, Self> {
-        Self::deserialize_compressed(bytes).map_err(|_| Error::DeserializationError)
-    }
-
     /// Retrieve \\( \alpha_{i0} * B \\), where \\( B \\) is the prime-order basepoint.
     pub fn public_key(&self) -> Option<&C::G> {
         if !self.points.is_empty() {

--- a/src/keys.rs
+++ b/src/keys.rs
@@ -4,6 +4,7 @@ use core::marker::PhantomData;
 use core::ops::{Deref, Mul};
 
 use crate::dkg::secret_share::VerifiableSecretSharingCommitment;
+use crate::serialization::impl_serialization_traits;
 use crate::sign::{compute_challenge, ThresholdSignature};
 use crate::utils::calculate_lagrange_coefficients;
 use crate::utils::{ToString, Vec};
@@ -21,22 +22,7 @@ use zeroize::Zeroize;
 #[derive(Clone, Debug, Eq, PartialEq, CanonicalSerialize, CanonicalDeserialize, Zeroize)]
 pub struct DiffieHellmanPrivateKey<C: CipherSuite>(pub(crate) <C::G as Group>::ScalarField);
 
-impl<C: CipherSuite> DiffieHellmanPrivateKey<C> {
-    /// Serialize this [`DiffieHellmanPrivateKey`] to a vector of bytes.
-    pub fn to_bytes(&self) -> FrostResult<C, Vec<u8>> {
-        let mut bytes = Vec::with_capacity(self.compressed_size());
-
-        self.serialize_compressed(&mut bytes)
-            .map_err(|_| Error::SerializationError)?;
-
-        Ok(bytes)
-    }
-
-    /// Attempt to deserialize a [`DiffieHellmanPrivateKey`] from a vector of bytes.
-    pub fn from_bytes(bytes: &[u8]) -> FrostResult<C, Self> {
-        Self::deserialize_compressed(bytes).map_err(|_| Error::DeserializationError)
-    }
-}
+impl_serialization_traits!(DiffieHellmanPrivateKey<CipherSuite>);
 
 impl<C: CipherSuite> Drop for DiffieHellmanPrivateKey<C> {
     fn drop(&mut self) {
@@ -51,6 +37,8 @@ pub struct DiffieHellmanPublicKey<C: CipherSuite> {
     _phantom: PhantomData<C>,
 }
 
+impl_serialization_traits!(DiffieHellmanPublicKey<CipherSuite>);
+
 impl<C: CipherSuite> DiffieHellmanPublicKey<C> {
     /// Instantiates a new [`DiffieHellmanPublicKey`] key.
     pub fn new(key: C::G) -> Self {
@@ -58,21 +46,6 @@ impl<C: CipherSuite> DiffieHellmanPublicKey<C> {
             key,
             _phantom: PhantomData,
         }
-    }
-
-    /// Serialize this [`DiffieHellmanPublicKey`] to a vector of bytes.
-    pub fn to_bytes(&self) -> FrostResult<C, Vec<u8>> {
-        let mut bytes = Vec::with_capacity(self.compressed_size());
-
-        self.serialize_compressed(&mut bytes)
-            .map_err(|_| Error::SerializationError)?;
-
-        Ok(bytes)
-    }
-
-    /// Attempt to deserialize a [`DiffieHellmanPublicKey`] from a vector of bytes.
-    pub fn from_bytes(bytes: &[u8]) -> FrostResult<C, Self> {
-        Self::deserialize_compressed(bytes).map_err(|_| Error::DeserializationError)
     }
 }
 
@@ -96,22 +69,9 @@ pub struct IndividualVerifyingKey<C: CipherSuite> {
     pub share: <C as CipherSuite>::G,
 }
 
+impl_serialization_traits!(IndividualVerifyingKey<CipherSuite>);
+
 impl<C: CipherSuite> IndividualVerifyingKey<C> {
-    /// Serialize this [`IndividualVerifyingKey`] to a vector of bytes.
-    pub fn to_bytes(&self) -> FrostResult<C, Vec<u8>> {
-        let mut bytes = Vec::with_capacity(self.compressed_size());
-
-        self.serialize_compressed(&mut bytes)
-            .map_err(|_| Error::SerializationError)?;
-
-        Ok(bytes)
-    }
-
-    /// Attempt to deserialize a [`IndividualVerifyingKey`] from a vector of bytes.
-    pub fn from_bytes(bytes: &[u8]) -> FrostResult<C, Self> {
-        Self::deserialize_compressed(bytes).map_err(|_| Error::DeserializationError)
-    }
-
     /// Any participant can compute the public verification share of any other participant.
     ///
     /// This is done by re-computing each [`IndividualVerifyingKey`] as \\(Y\_i\\) s.t.:
@@ -230,22 +190,7 @@ pub struct IndividualSigningKey<C: CipherSuite> {
     pub(crate) key: <C::G as Group>::ScalarField,
 }
 
-impl<C: CipherSuite> IndividualSigningKey<C> {
-    /// Serialize this [`IndividualSigningKey`] to a vector of bytes.
-    pub fn to_bytes(&self) -> FrostResult<C, Vec<u8>> {
-        let mut bytes = Vec::with_capacity(self.compressed_size());
-
-        self.serialize_compressed(&mut bytes)
-            .map_err(|_| Error::SerializationError)?;
-
-        Ok(bytes)
-    }
-
-    /// Attempt to deserialize a [`IndividualSigningKey`] from a vector of bytes.
-    pub fn from_bytes(bytes: &[u8]) -> FrostResult<C, Self> {
-        Self::deserialize_compressed(bytes).map_err(|_| Error::DeserializationError)
-    }
-}
+impl_serialization_traits!(IndividualSigningKey<CipherSuite>);
 
 impl<C: CipherSuite> Drop for IndividualSigningKey<C> {
     fn drop(&mut self) {
@@ -278,6 +223,8 @@ pub struct GroupVerifyingKey<C: CipherSuite> {
     _phantom: PhantomData<C>,
 }
 
+impl_serialization_traits!(GroupVerifyingKey<CipherSuite>);
+
 impl<C: CipherSuite> GroupVerifyingKey<C> {
     /// Instantiates a new [`GroupVerifyingKey`] key.
     pub fn new(key: C::G) -> Self {
@@ -306,20 +253,5 @@ impl<C: CipherSuite> GroupVerifyingKey<C> {
             true => Ok(()),
             false => Err(Error::InvalidSignature),
         }
-    }
-
-    /// Serialize this [`GroupVerifyingKey`] to a vector of bytes.
-    pub fn to_bytes(&self) -> FrostResult<C, Vec<u8>> {
-        let mut bytes = Vec::with_capacity(self.compressed_size());
-
-        self.serialize_compressed(&mut bytes)
-            .map_err(|_| Error::SerializationError)?;
-
-        Ok(bytes)
-    }
-
-    /// Attempt to deserialize a [`GroupVerifyingKey`] from a vector of bytes.
-    pub fn from_bytes(bytes: &[u8]) -> FrostResult<C, Self> {
-        Self::deserialize_compressed(bytes).map_err(|_| Error::DeserializationError)
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1227,6 +1227,10 @@ pub(crate) const HASH_SEC_PARAM: usize = 128;
 mod error;
 pub use error::{Error, FrostResult};
 
+/// A module defining traits for implementing convenient encoding and decoding to/from bytes.
+pub mod serialization;
+pub use serialization::{FromBytes, ToBytes};
+
 /// A module defining the different key types used by an ICE-FROST instance.
 pub mod keys;
 /// A module defining the [`ThresholdParameters`](crate::parameters::ThresholdParameters) type used by an ICE-FROST instance.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1228,7 +1228,7 @@ mod error;
 pub use error::{Error, FrostResult};
 
 /// A module defining traits for implementing convenient encoding and decoding to/from bytes.
-pub mod serialization;
+mod serialization;
 pub use serialization::{FromBytes, ToBytes};
 
 /// A module defining the different key types used by an ICE-FROST instance.

--- a/src/parameters.rs
+++ b/src/parameters.rs
@@ -3,8 +3,8 @@
 use core::marker::PhantomData;
 
 use crate::ciphersuite::CipherSuite;
+use crate::serialization::impl_serialization_traits;
 use crate::utils::Vec;
-use crate::{Error, FrostResult};
 
 use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
 
@@ -18,6 +18,8 @@ pub struct ThresholdParameters<C: CipherSuite> {
     pub t: u32,
     _phantom: PhantomData<C>,
 }
+
+impl_serialization_traits!(ThresholdParameters<CipherSuite>);
 
 impl<C: CipherSuite> ThresholdParameters<C> {
     /// Initialize a new set of threshold parameters.
@@ -37,27 +39,13 @@ impl<C: CipherSuite> ThresholdParameters<C> {
             _phantom: PhantomData,
         }
     }
-
-    /// Serialize this [`ThresholdParameters`] to a vector of bytes.
-    pub fn to_bytes(&self) -> FrostResult<C, Vec<u8>> {
-        let mut bytes = Vec::with_capacity(self.compressed_size());
-
-        self.serialize_compressed(&mut bytes)
-            .map_err(|_| Error::SerializationError)?;
-
-        Ok(bytes)
-    }
-
-    /// Attempt to deserialize a [`ThresholdParameters`] from a vector of bytes.
-    pub fn from_bytes(bytes: &[u8]) -> FrostResult<C, Self> {
-        Self::deserialize_compressed(bytes).map_err(|_| Error::DeserializationError)
-    }
 }
 
 #[cfg(test)]
 mod test {
     use super::*;
     use crate::testing::Secp256k1Sha256;
+    use crate::{FromBytes, ToBytes};
     use rand::{rngs::OsRng, RngCore};
 
     #[test]

--- a/src/serialization.rs
+++ b/src/serialization.rs
@@ -1,0 +1,36 @@
+use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
+
+use crate::{CipherSuite, Error, FrostResult};
+
+/// Utility trait for serializing an ICE-FROST object to a vector of bytes.
+pub trait ToBytes<C: CipherSuite>: CanonicalSerialize {
+    /// Serialize this to a vector of bytes.
+    fn to_bytes(&self) -> FrostResult<C, Vec<u8>> {
+        let mut bytes = Vec::with_capacity(self.compressed_size());
+
+        <Self as CanonicalSerialize>::serialize_compressed(self, &mut bytes)
+            .map_err(|_| Error::SerializationError)?;
+
+        Ok(bytes)
+    }
+}
+
+/// Utility trait for deserializing an ICE-FROST object from a slice of bytes.
+pub trait FromBytes<C: CipherSuite>: CanonicalDeserialize {
+    /// Attempt to deserialize a `T` from a vector of bytes.
+    fn from_bytes(bytes: &[u8]) -> FrostResult<C, Self> {
+        Self::deserialize_compressed(bytes).map_err(|_| Error::DeserializationError)
+    }
+}
+
+/// Utility macro for easily deriving `ToBytes` and `FromBytes` traits.
+macro_rules! impl_serialization_traits {
+    ($type_name:ident <$gen_param:ident>) => {
+        impl<$gen_param: crate::CipherSuite> crate::ToBytes<$gen_param> for $type_name<$gen_param> {}
+        impl<$gen_param: crate::CipherSuite> crate::FromBytes<$gen_param>
+            for $type_name<$gen_param>
+        {
+        }
+    };
+}
+pub(crate) use impl_serialization_traits;

--- a/src/serialization.rs
+++ b/src/serialization.rs
@@ -1,5 +1,6 @@
 use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
 
+use crate::utils::Vec;
 use crate::{CipherSuite, Error, FrostResult};
 
 /// Utility trait for serializing an ICE-FROST object to a vector of bytes.

--- a/src/sign/precomputation.rs
+++ b/src/sign/precomputation.rs
@@ -5,8 +5,10 @@
 use core::ops::Mul;
 
 use crate::keys::IndividualSigningKey;
+use crate::serialization::impl_serialization_traits;
 use crate::utils::{Scalar, Vec};
-use crate::{Error, FrostResult};
+use crate::FrostResult;
+use crate::ToBytes;
 
 use crate::ciphersuite::CipherSuite;
 
@@ -112,22 +114,7 @@ pub struct CommitmentShare<C: CipherSuite> {
     pub(crate) binding: Commitment<C>,
 }
 
-impl<C: CipherSuite> CommitmentShare<C> {
-    /// Serialize this [`CommitmentShare`] to a vector of bytes.
-    pub fn to_bytes(&self) -> FrostResult<C, Vec<u8>> {
-        let mut bytes = Vec::with_capacity(self.compressed_size());
-
-        self.serialize_compressed(&mut bytes)
-            .map_err(|_| Error::SerializationError)?;
-
-        Ok(bytes)
-    }
-
-    /// Attempt to deserialize a [`CommitmentShare`] from a vector of bytes.
-    pub fn from_bytes(bytes: &[u8]) -> FrostResult<C, Self> {
-        Self::deserialize_compressed(bytes).map_err(|_| Error::DeserializationError)
-    }
-}
+impl_serialization_traits!(CommitmentShare<CipherSuite>);
 
 impl<C: CipherSuite> Drop for CommitmentShare<C> {
     fn drop(&mut self) {
@@ -157,22 +144,7 @@ pub struct SecretCommitmentShareList<C: CipherSuite> {
     pub commitments: Vec<CommitmentShare<C>>,
 }
 
-impl<C: CipherSuite> SecretCommitmentShareList<C> {
-    /// Serialize this [`SecretCommitmentShareList`] to a vector of bytes.
-    pub fn to_bytes(&self) -> FrostResult<C, Vec<u8>> {
-        let mut bytes = Vec::with_capacity(self.compressed_size());
-
-        self.serialize_compressed(&mut bytes)
-            .map_err(|_| Error::SerializationError)?;
-
-        Ok(bytes)
-    }
-
-    /// Attempt to deserialize a [`SecretCommitmentShareList`] from a vector of bytes.
-    pub fn from_bytes(bytes: &[u8]) -> FrostResult<C, Self> {
-        Self::deserialize_compressed(bytes).map_err(|_| Error::DeserializationError)
-    }
-}
+impl_serialization_traits!(SecretCommitmentShareList<CipherSuite>);
 
 /// A public commitment share list, containing only the hiding and binding
 /// commitments, *not* their committed-to secret values.
@@ -187,22 +159,7 @@ pub struct PublicCommitmentShareList<C: CipherSuite> {
     pub commitments: Vec<(C::G, C::G)>,
 }
 
-impl<C: CipherSuite> PublicCommitmentShareList<C> {
-    /// Serialize this [`PublicCommitmentShareList`] to a vector of bytes.
-    pub fn to_bytes(&self) -> FrostResult<C, Vec<u8>> {
-        let mut bytes = Vec::with_capacity(self.compressed_size());
-
-        self.serialize_compressed(&mut bytes)
-            .map_err(|_| Error::SerializationError)?;
-
-        Ok(bytes)
-    }
-
-    /// Attempt to deserialize a [`PublicCommitmentShareList`] from a vector of bytes.
-    pub fn from_bytes(bytes: &[u8]) -> FrostResult<C, Self> {
-        Self::deserialize_compressed(bytes).map_err(|_| Error::DeserializationError)
-    }
-}
+impl_serialization_traits!(PublicCommitmentShareList<CipherSuite>);
 
 /// Pre-compute a list of [`CommitmentShare`]s for single-round threshold signing.
 ///

--- a/src/sign/signature.rs
+++ b/src/sign/signature.rs
@@ -3,6 +3,7 @@
 //! their public aggregation.
 
 use crate::ciphersuite::CipherSuite;
+use crate::serialization::impl_serialization_traits;
 
 use ark_ec::{Group, VariableBaseMSM};
 use ark_ff::{Field, Zero};
@@ -61,22 +62,7 @@ pub struct PartialThresholdSignature<C: CipherSuite> {
     pub(crate) z: Scalar<C>,
 }
 
-impl<C: CipherSuite> PartialThresholdSignature<C> {
-    /// Serialize this [`PartialThresholdSignature`] to a vector of bytes.
-    pub fn to_bytes(&self) -> FrostResult<C, Vec<u8>> {
-        let mut bytes = Vec::with_capacity(self.compressed_size());
-
-        self.serialize_compressed(&mut bytes)
-            .map_err(|_| Error::SerializationError)?;
-
-        Ok(bytes)
-    }
-
-    /// Attempt to deserialize a [`PartialThresholdSignature`] from a vector of bytes.
-    pub fn from_bytes(bytes: &[u8]) -> FrostResult<C, Self> {
-        Self::deserialize_compressed(bytes).map_err(|_| Error::DeserializationError)
-    }
-}
+impl_serialization_traits!(PartialThresholdSignature<CipherSuite>);
 
 /// A complete, aggregated threshold signature.
 #[derive(Debug, Eq, PartialEq, CanonicalSerialize, CanonicalDeserialize)]
@@ -85,22 +71,7 @@ pub struct ThresholdSignature<C: CipherSuite> {
     pub(crate) z: Scalar<C>,
 }
 
-impl<C: CipherSuite> ThresholdSignature<C> {
-    /// Serialize this [`ThresholdSignature`] to a vector of bytes.
-    pub fn to_bytes(&self) -> FrostResult<C, Vec<u8>> {
-        let mut bytes = Vec::with_capacity(self.compressed_size());
-
-        self.serialize_compressed(&mut bytes)
-            .map_err(|_| Error::SerializationError)?;
-
-        Ok(bytes)
-    }
-
-    /// Attempt to deserialize a [`ThresholdSignature`] from a vector of bytes.
-    pub fn from_bytes(bytes: &[u8]) -> FrostResult<C, Self> {
-        Self::deserialize_compressed(bytes).map_err(|_| Error::DeserializationError)
-    }
-}
+impl_serialization_traits!(ThresholdSignature<CipherSuite>);
 
 /// A struct for storing signers' binding factors with their index.
 #[derive(Debug, Default, CanonicalSerialize, CanonicalDeserialize)]
@@ -746,6 +717,7 @@ mod test {
     use crate::keys::DiffieHellmanPrivateKey;
     use crate::sign::{generate_commitment_share_lists, PublicCommitmentShareList};
     use crate::testing::Secp256k1Sha256;
+    use crate::{FromBytes, ToBytes};
 
     use ark_secp256k1::{Fr, Projective};
 


### PR DESCRIPTION
# Description

Remove all the code duplication around the `to_bytes` / `from_bytes` methods by having them behind dedicated traits which implementation follows from `CanonicalSerialize` / `CanonicalDeserialize`, as before.

Only `DistributedKeyGeneration<S, C>` can't use the `macro!` as it has two associated traits instead of just `CipherSuite`, and I am bad at writing macros 😅  Happy to hear any suggestions to improve that though.

## PR Checklist:

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added or updated tests that comprehensively prove my change is effective or that my feature works
