### PR TITLE
Update crypto deps and add a new `Cipher` associated type

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ exclude = [ ".gitignore" ]
 rustdoc-args = ["--html-in-header", "/opt/rustwide/workdir/docs/assets/rustdoc-include-katex-header.html"]
 
 [dependencies]
+aead = { version = "0.5", default-features = false, features = ["alloc", "getrandom"]}
 ark-secp256k1 = { version = "0.4", default-features = false }
 ark-ff = { version = "0.4", default-features = false }
 ark-ec = { version = "0.4", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ digest = { version = "0.10", default-features = false, features = ["alloc"] }
 getrandom = { version = "0.2", default-features = false, features = ["js"] }
 rand = { version = "0.8", default-features = false, features = ["alloc", "getrandom", "libc"] }
 sha2 = { version = "0.10", default-features = false }
-aes = { version = "0.7", default-features = false, features = ["ctr"] }
+aes-gcm = { version = "0.10", default-features = false, features = ["aes", "alloc", "getrandom", "zeroize"] }
 hkdf = { version = "0.12", default-features = false }
 zeroize = { version = "1", default-features = false, features = ["alloc", "zeroize_derive"] }
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Note however that two parameters are not modular, at least in the current versio
 
 - the hash function targeted security parameter: this crate assumes 128 bits of collision security for the ciphersuite's internal hashers. One **MUST** provide
   a hasher with _at least_ 128 bits of collision security when instantiating an ICE-FROST ciphersuite.
-- the secret share encryption mechanism: this part of the distributed key generation currently relies on AES128-CTR with HKDF instantiated from SHA-256.
+- the secret share encryption mechanism: this part of the distributed key generation currently relies on AES128-GCM with HKDF instantiated from SHA-256.
 
 This library also provides by default an example instantiation over the Secp256k1 curve with SHA-256, to be used in tests and benchmarks.
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,8 @@ Please see the documentation for usage examples.
 This library has a modular backend supporting
 
 - arbitrary curves defined with the arkworks library suite;
-- arbitrary hash functions for the internal random oracles of the ICE-FROST ciphersuite.
+- arbitrary hash functions for the internal random oracles of the ICE-FROST ciphersuite;
+- an arbitrary AEAD for the secret shares encryption part of the DKG / Key resharing phase.
 
 Note however that two parameters are not modular, at least in the current version:
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Note however that two parameters are not modular, at least in the current versio
 
 - the hash function targeted security parameter: this crate assumes 128 bits of collision security for the ciphersuite's internal hashers. One **MUST** provide
   a hasher with _at least_ 128 bits of collision security when instantiating an ICE-FROST ciphersuite.
-- the secret share encryption mechanism: this part of the distributed key generation currently relies on AES128-GCM with HKDF instantiated from SHA-256.
+- the secret share encryption mechanism: this part of the distributed key generation currently relies on the ciphersuite's AEAD but with a fixed HKDF instantiated from SHA-256.
 
 This library also provides by default an example instantiation over the Secp256k1 curve with SHA-256, to be used in tests and benchmarks.
 

--- a/src/ciphersuite.rs
+++ b/src/ciphersuite.rs
@@ -3,6 +3,7 @@
 use core::fmt::Debug;
 use core::marker::{Send, Sync};
 
+use aead::{Aead, KeyInit};
 use zeroize::Zeroize;
 
 use ark_ec::CurveGroup;
@@ -26,6 +27,9 @@ pub trait CipherSuite: Copy + Clone + PartialEq + Eq + Debug + Send + Sync + Zer
 
     /// The underlying hasher used to construct all random oracles of this [`CipherSuite`] .
     type InnerHasher: Default + Clone + Digest + DynDigest;
+
+    /// The underlying hasher used to construct all random oracles of this [`CipherSuite`] .
+    type Cipher: Aead + KeyInit;
 
     //////////////////////////////////////////////////////////////////////////////////////////////
 

--- a/src/ciphersuite.rs
+++ b/src/ciphersuite.rs
@@ -25,10 +25,11 @@ pub trait CipherSuite: Copy + Clone + PartialEq + Eq + Debug + Send + Sync + Zer
     /// A byte array of a given length for this [`CipherSuite`]'s binary hashers.
     type HashOutput: AsRef<[u8]> + AsMut<[u8]> + Default;
 
-    /// The underlying hasher used to construct all random oracles of this [`CipherSuite`] .
+    /// The underlying hasher used to construct all random oracles of this [`CipherSuite`].
     type InnerHasher: Default + Clone + Digest + DynDigest;
 
-    /// The underlying hasher used to construct all random oracles of this [`CipherSuite`] .
+    /// The underlying cipher used to encrypt and decrypt all `SecretShare`
+    /// generated during a DKG phase of this [`CipherSuite`].
     type Cipher: Aead + KeyInit + Clone;
 
     //////////////////////////////////////////////////////////////////////////////////////////////

--- a/src/ciphersuite.rs
+++ b/src/ciphersuite.rs
@@ -29,7 +29,7 @@ pub trait CipherSuite: Copy + Clone + PartialEq + Eq + Debug + Send + Sync + Zer
     type InnerHasher: Default + Clone + Digest + DynDigest;
 
     /// The underlying hasher used to construct all random oracles of this [`CipherSuite`] .
-    type Cipher: Aead + KeyInit;
+    type Cipher: Aead + KeyInit + Clone;
 
     //////////////////////////////////////////////////////////////////////////////////////////////
 

--- a/src/dkg/complaint.rs
+++ b/src/dkg/complaint.rs
@@ -11,6 +11,7 @@ use rand::{CryptoRng, RngCore};
 use sha2::Sha256;
 
 use crate::ciphersuite::CipherSuite;
+use crate::HASH_SEC_PARAM;
 
 use ark_ec::Group;
 use ark_ff::field_hashers::{DefaultFieldHasher, HashToField};
@@ -47,7 +48,7 @@ impl<C: CipherSuite> Complaint<C> {
         let a1 = C::G::generator().mul(r);
         let a2 = accused_pk.mul(r);
 
-        let hasher = <DefaultFieldHasher<Sha256, 128> as HashToField<Scalar<C>>>::new(
+        let hasher = <DefaultFieldHasher<Sha256, HASH_SEC_PARAM> as HashToField<Scalar<C>>>::new(
             "Complaint Context".as_bytes(),
         );
 
@@ -84,7 +85,7 @@ impl<C: CipherSuite> Complaint<C> {
     /// --  a1 + h.pk_i = z.g
     /// --  a2 + h.k_il = z.pk_l
     pub fn verify(&self, pk_i: &C::G, pk_l: &C::G) -> FrostResult<C, ()> {
-        let hasher = <DefaultFieldHasher<Sha256, 128> as HashToField<Scalar<C>>>::new(
+        let hasher = <DefaultFieldHasher<Sha256, HASH_SEC_PARAM> as HashToField<Scalar<C>>>::new(
             "Complaint Context".as_bytes(),
         );
 

--- a/src/dkg/key_generation.rs
+++ b/src/dkg/key_generation.rs
@@ -2075,7 +2075,7 @@ mod test {
             // Wrong decryption from nonce
             {
                 let mut wrong_encrypted_secret_share = p1_their_encrypted_secret_shares[1].clone();
-                wrong_encrypted_secret_share.nonce = [42; 12];
+                wrong_encrypted_secret_share.nonce = [42; 12].into();
                 let p1_my_encrypted_secret_shares = vec![
                     p1_their_encrypted_secret_shares[0].clone(),
                     p2_their_encrypted_secret_shares[0].clone(),
@@ -2404,7 +2404,7 @@ mod test {
 
             {
                 let wrong_encrypted_secret_share =
-                    EncryptedSecretShare::new(1, 2, [0; 12], vec![0]);
+                    EncryptedSecretShare::new(1, 2, [0; 12].into(), vec![0]);
 
                 let p1_my_encrypted_secret_shares = vec![
                     p1_their_encrypted_secret_shares[0].clone(),

--- a/src/dkg/key_generation.rs
+++ b/src/dkg/key_generation.rs
@@ -2075,7 +2075,7 @@ mod test {
             // Wrong decryption from nonce
             {
                 let mut wrong_encrypted_secret_share = p1_their_encrypted_secret_shares[1].clone();
-                wrong_encrypted_secret_share.nonce = [42; 16];
+                wrong_encrypted_secret_share.nonce = [42; 12];
                 let p1_my_encrypted_secret_shares = vec![
                     p1_their_encrypted_secret_shares[0].clone(),
                     p2_their_encrypted_secret_shares[0].clone(),
@@ -2404,7 +2404,7 @@ mod test {
 
             {
                 let wrong_encrypted_secret_share =
-                    EncryptedSecretShare::new(1, 2, [0; 16], vec![0]);
+                    EncryptedSecretShare::new(1, 2, [0; 12], vec![0]);
 
                 let p1_my_encrypted_secret_shares = vec![
                     p1_their_encrypted_secret_shares[0].clone(),

--- a/src/dkg/secret_share.rs
+++ b/src/dkg/secret_share.rs
@@ -12,6 +12,9 @@ use crate::serialization::impl_serialization_traits;
 use crate::utils::{Scalar, ToString, Vec};
 use crate::{Error, FrostResult};
 
+#[cfg(not(feature = "std"))]
+use alloc::vec;
+
 use crate::ciphersuite::CipherSuite;
 
 use ark_ec::{CurveGroup, Group};

--- a/src/dkg/secret_share.rs
+++ b/src/dkg/secret_share.rs
@@ -158,6 +158,9 @@ impl<C: CipherSuite> ark_serialize::Valid for EncryptedSecretShare<C> {
     fn check(&self) -> Result<(), ark_serialize::SerializationError> {
         self.sender_index.check()?;
         self.receiver_index.check()?;
+        // Collecting is not ideal for this and the `serialize_with_mode` / `deserialize_with_mode`
+        // implementation below, but is necessary, at least until the `GenericArray` dependency of
+        // the aead trait gets bumped to 1.0.
         self.nonce.to_vec().check()?;
         self.encrypted_polynomial_evaluation.check()
     }

--- a/src/error.rs
+++ b/src/error.rs
@@ -19,6 +19,8 @@ pub enum Error<C: CipherSuite> {
     DecompressionError,
     /// Encrypted secret share decryption failure
     DecryptionError,
+    /// Secret share encryption failure
+    EncryptionError,
     /// Secret share verification failure
     ShareVerificationError,
     /// Complaint verification failure
@@ -72,6 +74,9 @@ impl<C: CipherSuite> core::fmt::Display for Error<C> {
             }
             Error::DecryptionError => {
                 write!(f, "Could not decrypt encrypted share.")
+            }
+            Error::EncryptionError => {
+                write!(f, "Could not encrypt secret share.")
             }
             Error::ShareVerificationError => {
                 write!(f, "The secret share is not correct.")

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,12 +18,14 @@
 //! This CipherSuite is used to parameterize ICE-FROST over an arbitrary curve backend, with
 //! an arbitrary underlying hasher instantiating all random oracles.
 //! The following example creates an ICE-FROST CipherSuite over the Secp256k1 curve,
-//! with SHA-256 as internal hash function.
+//! with SHA-256 as internal hash function, and AES-GCM with a 128-bit key and 96-bit nonce
+//! as internal block cipher.
 //!
 //! ```rust
 //! use ice_frost::CipherSuite;
 //! use sha2::Sha256;
 //! use zeroize::Zeroize;
+//! use aes_gcm::Aes128Gcm;
 //! use ark_secp256k1::Projective as G;
 //!
 //! #[derive(Debug, Copy, Clone, PartialEq, Eq, Default, Zeroize)]
@@ -35,6 +37,8 @@
 //!     type HashOutput = [u8; 32];
 //!
 //!     type InnerHasher = Sha256;
+//!
+//!     type Cipher = Aes128Gcm;
 //!
 //!     fn context_string() -> String {
 //!         "ICE-FROST_SECP256K1_SHA256".to_owned()
@@ -1255,6 +1259,7 @@ pub mod sign;
 pub mod testing {
     use super::*;
 
+    use aes_gcm::Aes128Gcm;
     use ark_secp256k1::Projective as G;
 
     use sha2::Sha256;
@@ -1272,6 +1277,8 @@ pub mod testing {
         type HashOutput = [u8; 32];
 
         type InnerHasher = Sha256;
+
+        type Cipher = Aes128Gcm;
 
         fn context_string() -> String {
             "ICE-FROST_SECP256K1_SHA256".to_owned()


### PR DESCRIPTION
# Description

This PR generalizes the use of AES to any AEAD, to be used during share encryption, and updates the mode used in testing to be AES-GCM.

## Additions and Changes

The outstanding changes are:
- a new associated type to `CipherSuite`, namely `Cipher`, to be used during Dkg / Resharing to encrypt/decrypt secret shares. It must implement the `Aead` (for (de/en)crypting) and `KeyInit` (for Key initialization from the output of the HKDF) traits (+ `Clone` because that's convenient).
- a type change for the `nonce` field of `EncryptedSecretShare`: it now is a `Nonce<C::Cipher>` which conveniently wraps around a `GenericArray` to give some guarantees on the expected underlying length, and remove the current hardcoded nonce length.
- the default `Cipher` for testing is now `Aes128Gcm`. The rationale is that
  - following a bump of the `aes` crate from v0.7 to v0.8, there's been a big refactor removing among others the `ctr` mode
  - gcm is much better than ctr

Note that I didn't go for the `aes-gcm-siv` crate as:
- the available structure implementing the `Ciphersuite` trait is, as mentioned, only for testing purposes
- we don't really care about nonce reuse at this level, as even if `Aes128Gcm` was used as internal cipher in production, we'd need over 4 billion encryption over the same initial DH key to have problems...

Note that because of the new `C::Cipher` type, and the use of `Aes128Gcm` in testing, I had to manually implement several of the previously derived traits for `EncryptedSecretShare`. The `nonce` field for (de)serialization requires collecting, though shouldn't be a bottleneck hence I left it as a `Vec`.


## PR Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added or updated tests that comprehensively prove my change is effective or that my feature works
