### PR TITLE
Remove unnecessary panics

### DIFF
--- a/benches/sign.rs
+++ b/benches/sign.rs
@@ -126,7 +126,8 @@ fn criterion_benchmark(c: &mut Criterion) {
     let mut participants_secret_comshares =
         Vec::<SecretCommShareList>::with_capacity(NUMBER_OF_PARTICIPANTS as usize);
     let (p1_public_comshares, p1_secret_comshares) =
-        generate_commitment_share_lists(&mut OsRng, &participants_secret_keys[0].clone(), 1);
+        generate_commitment_share_lists(&mut OsRng, &participants_secret_keys[0].clone(), 1)
+            .unwrap();
     participants_public_comshares.push(p1_public_comshares);
     participants_secret_comshares.push(p1_secret_comshares.clone());
 
@@ -135,7 +136,8 @@ fn criterion_benchmark(c: &mut Criterion) {
             &mut OsRng,
             &participants_secret_keys[(i - 1) as usize].clone(),
             1,
-        );
+        )
+        .unwrap();
         participants_public_comshares.push(pi_public_comshares);
         participants_secret_comshares.push(pi_secret_comshares);
     }

--- a/src/dkg/key_generation.rs
+++ b/src/dkg/key_generation.rs
@@ -1008,7 +1008,7 @@ impl<C: CipherSuite> DistributedKeyGeneration<RoundTwo, C> {
 
             group_key += commitment
                 .public_key()
-                .expect("We should always be able to retrieve a public key from ")
+                .expect("We should always be able to retrieve a public key from a commitment.")
                 .mul(coeff);
         }
 

--- a/src/dkg/participant.rs
+++ b/src/dkg/participant.rs
@@ -85,8 +85,11 @@ impl<C: CipherSuite> Participant<C> {
     ) -> FrostResult<C, (Self, Coefficients<C>, DiffieHellmanPrivateKey<C>)> {
         let (dealer, coeff_option, dh_private_key) =
             Self::new_internal(parameters, false, index, None, &mut rng)?;
-        // This unwrap() cannot fail, as we always have at least an empty vector of coefficients.
-        Ok((dealer, coeff_option.unwrap(), dh_private_key))
+        Ok((
+            dealer,
+            coeff_option.expect("We always have at least an empty vector"),
+            dh_private_key,
+        ))
     }
 
     /// Construct a new signer for the distributed key generation protocol.
@@ -196,7 +199,9 @@ impl<C: CipherSuite> Participant<C> {
             let proof_of_secret_key: NizkPokOfSecretKey<C> = NizkPokOfSecretKey::prove(
                 index,
                 &coefficients.0[0],
-                commitments.public_key().unwrap(),
+                commitments
+                    .public_key()
+                    .expect("We should always be able to retrieve a public key."),
                 rng,
             )?;
 
@@ -250,8 +255,7 @@ impl<C: CipherSuite> Participant<C> {
             &mut rng,
         )?;
 
-        // This unwrap() cannot fail, as we always have at least an empty vector of coefficients.
-        let coefficients = coeff_option.unwrap();
+        let coefficients = coeff_option.expect("We always have at least an empty vector");
 
         let (participant_state, participant_lists) = DistributedKeyGeneration::new_state_internal(
             parameters,

--- a/src/dkg/participant.rs
+++ b/src/dkg/participant.rs
@@ -85,6 +85,7 @@ impl<C: CipherSuite> Participant<C> {
     ) -> FrostResult<C, (Self, Coefficients<C>, DiffieHellmanPrivateKey<C>)> {
         let (dealer, coeff_option, dh_private_key) =
             Self::new_internal(parameters, false, index, None, &mut rng)?;
+        // This unwrap() cannot fail, as we always have at least an empty vector of coefficients.
         Ok((dealer, coeff_option.unwrap(), dh_private_key))
     }
 
@@ -249,7 +250,7 @@ impl<C: CipherSuite> Participant<C> {
             &mut rng,
         )?;
 
-        // Unwrapping cannot panic here
+        // This unwrap() cannot fail, as we always have at least an empty vector of coefficients.
         let coefficients = coeff_option.unwrap();
 
         let (participant_state, participant_lists) = DistributedKeyGeneration::new_state_internal(
@@ -263,11 +264,7 @@ impl<C: CipherSuite> Participant<C> {
             &mut rng,
         )?;
 
-        // Unwrapping cannot panic here
-        let encrypted_shares = participant_state
-            .their_encrypted_secret_shares()
-            .unwrap()
-            .clone();
+        let encrypted_shares = participant_state.their_encrypted_secret_shares()?.clone();
 
         Ok((dealer, encrypted_shares, participant_lists))
     }
@@ -276,11 +273,7 @@ impl<C: CipherSuite> Participant<C> {
     ///
     /// This is used to pass into the final call to [`DistributedKeyGeneration::<RoundTwo, C>::finish()`] .
     pub fn public_key(&self) -> Option<&C::G> {
-        if self.commitments.is_some() {
-            return self.commitments.as_ref().unwrap().public_key();
-        }
-
-        None
+        self.commitments.as_ref().map(|c| c.public_key())?
     }
 }
 

--- a/src/dkg/secret_share.rs
+++ b/src/dkg/secret_share.rs
@@ -233,7 +233,7 @@ pub(crate) fn decrypt_share<C: CipherSuite>(
     let hkdf = Hkdf::<Sha256>::new(None, aes_key);
     let mut final_aes_key = [0u8; 16];
     hkdf.expand(&[], &mut final_aes_key)
-        .expect("KDF expansion failed unexpectedly");
+        .map_err(|_| Error::Custom("KDF expansion failed unexpectedly".to_string()))?;
 
     let final_aes_key = GenericArray::from_slice(&final_aes_key);
 

--- a/src/keys.rs
+++ b/src/keys.rs
@@ -150,7 +150,7 @@ impl<C: CipherSuite> IndividualVerifyingKey<C> {
     pub fn generate_from_commitments(
         participant_index: u32,
         commitments: &[VerifiableSecretSharingCommitment<C>],
-    ) -> Self {
+    ) -> FrostResult<C, Self> {
         let mut share: C::G = <C as CipherSuite>::G::zero();
         let term: <C::G as Group>::ScalarField = participant_index.into();
 
@@ -169,15 +169,14 @@ impl<C: CipherSuite> IndividualVerifyingKey<C> {
                 }
             }
 
-            let coeff =
-                calculate_lagrange_coefficients::<C>(commitment.index, &index_vector).unwrap();
+            let coeff = calculate_lagrange_coefficients::<C>(commitment.index, &index_vector)?;
             share += tmp * coeff;
         }
 
-        IndividualVerifyingKey {
+        Ok(IndividualVerifyingKey {
             index: participant_index,
             share,
-        }
+        })
     }
 }
 
@@ -240,8 +239,7 @@ impl<C: CipherSuite> GroupVerifyingKey<C> {
         signature: &ThresholdSignature<C>,
         message_hash: &[u8],
     ) -> FrostResult<C, ()> {
-        let challenge =
-            compute_challenge::<C>(&signature.group_commitment, self, message_hash).unwrap();
+        let challenge = compute_challenge::<C>(&signature.group_commitment, self, message_hash)?;
 
         let retrieved_commitment: C::G = <C as CipherSuite>::G::msm(
             &[C::G::generator().into(), (-self.key).into()],

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -908,11 +908,11 @@
 //! # let carol_public_key = carol_secret_key.to_public();
 //!
 //! let (alice_public_comshares, mut alice_secret_comshares) =
-//!     generate_commitment_share_lists::<Secp256k1Sha256>(&mut rng, &alice_secret_key, 1);
+//!     generate_commitment_share_lists::<Secp256k1Sha256>(&mut rng, &alice_secret_key, 1)?;
 //! let (bob_public_comshares, mut bob_secret_comshares) =
-//!     generate_commitment_share_lists::<Secp256k1Sha256>(&mut rng, &bob_secret_key, 1);
+//!     generate_commitment_share_lists::<Secp256k1Sha256>(&mut rng, &bob_secret_key, 1)?;
 //! let (carol_public_comshares, mut carol_secret_comshares) =
-//!     generate_commitment_share_lists::<Secp256k1Sha256>(&mut rng, &carol_secret_key, 1);
+//!     generate_commitment_share_lists::<Secp256k1Sha256>(&mut rng, &carol_secret_key, 1)?;
 //!
 //! let message = b"This is a test of the tsunami alert system. This is only a test.";
 //!
@@ -987,11 +987,11 @@
 //! # let carol_public_key = carol_secret_key.to_public();
 //! #
 //! # let (alice_public_comshares, mut alice_secret_comshares) =
-//! #     generate_commitment_share_lists::<Secp256k1Sha256>(&mut rng, &alice_secret_key, 1);
+//! #     generate_commitment_share_lists::<Secp256k1Sha256>(&mut rng, &alice_secret_key, 1)?;
 //! # let (bob_public_comshares, mut bob_secret_comshares) =
-//! #     generate_commitment_share_lists::<Secp256k1Sha256>(&mut rng, &bob_secret_key, 1);
+//! #     generate_commitment_share_lists::<Secp256k1Sha256>(&mut rng, &bob_secret_key, 1)?;
 //! # let (carol_public_comshares, mut carol_secret_comshares) =
-//! #     generate_commitment_share_lists::<Secp256k1Sha256>(&mut rng, &carol_secret_key, 1);
+//! #     generate_commitment_share_lists::<Secp256k1Sha256>(&mut rng, &carol_secret_key, 1)?;
 //! #
 //! # let message = b"This is a test of the tsunami alert system. This is only a test.";
 //! #
@@ -1061,11 +1061,11 @@
 //! # let carol_public_key = carol_secret_key.to_public();
 //! #
 //! # let (alice_public_comshares, mut alice_secret_comshares) =
-//! #     generate_commitment_share_lists::<Secp256k1Sha256>(&mut rng, &alice_secret_key, 1);
+//! #     generate_commitment_share_lists::<Secp256k1Sha256>(&mut rng, &alice_secret_key, 1)?;
 //! # let (bob_public_comshares, mut bob_secret_comshares) =
-//! #     generate_commitment_share_lists::<Secp256k1Sha256>(&mut rng, &bob_secret_key, 1);
+//! #     generate_commitment_share_lists::<Secp256k1Sha256>(&mut rng, &bob_secret_key, 1)?;
 //! # let (carol_public_comshares, mut carol_secret_comshares) =
-//! #     generate_commitment_share_lists::<Secp256k1Sha256>(&mut rng, &carol_secret_key, 1);
+//! #     generate_commitment_share_lists::<Secp256k1Sha256>(&mut rng, &carol_secret_key, 1)?;
 //! #
 //! # let message = b"This is a test of the tsunami alert system. This is only a test.";
 //! #
@@ -1135,11 +1135,11 @@
 //! # let carol_public_key = carol_secret_key.to_public();
 //! #
 //! # let (alice_public_comshares, mut alice_secret_comshares) =
-//! #     generate_commitment_share_lists::<Secp256k1Sha256>(&mut rng, &alice_secret_key, 1);
+//! #     generate_commitment_share_lists::<Secp256k1Sha256>(&mut rng, &alice_secret_key, 1)?;
 //! # let (bob_public_comshares, mut bob_secret_comshares) =
-//! #     generate_commitment_share_lists::<Secp256k1Sha256>(&mut rng, &bob_secret_key, 1);
+//! #     generate_commitment_share_lists::<Secp256k1Sha256>(&mut rng, &bob_secret_key, 1)?;
 //! # let (carol_public_comshares, mut carol_secret_comshares) =
-//! #     generate_commitment_share_lists::<Secp256k1Sha256>(&mut rng, &carol_secret_key, 1);
+//! #     generate_commitment_share_lists::<Secp256k1Sha256>(&mut rng, &carol_secret_key, 1)?;
 //! #
 //! # let message = b"This is a test of the tsunami alert system. This is only a test.";
 //! #
@@ -1149,7 +1149,7 @@
 //! # aggregator.include_signer(3, carol_public_comshares.commitments[0], (&carol_secret_key).into());
 //! #
 //! # let signers = aggregator.get_signers();
-//! # let message_hash = Secp256k1Sha256::h4(&message[..]).unwrap();
+//! # let message_hash = Secp256k1Sha256::h4(&message[..])?;
 //!
 //! let alice_partial = alice_secret_key.sign(
 //!     &message_hash,

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -17,7 +17,7 @@ pub use std::{
     boxed::Box,
     collections::btree_map::BTreeMap,
     string::{String, ToString},
-    vec::{self, Vec},
+    vec::Vec,
 };
 
 use crate::{ciphersuite::CipherSuite, HASH_SEC_PARAM};

--- a/tests/ice_frost.rs
+++ b/tests/ice_frost.rs
@@ -112,11 +112,11 @@ fn signing_and_verification_3_out_of_5() {
 
     let message = b"This is a test of the tsunami alert system. This is only a test.";
     let (p1_public_comshares, mut p1_secret_comshares) =
-        generate_commitment_share_lists(&mut OsRng, &p1_sk, 1);
+        generate_commitment_share_lists(&mut OsRng, &p1_sk, 1).unwrap();
     let (p3_public_comshares, mut p3_secret_comshares) =
-        generate_commitment_share_lists(&mut OsRng, &p3_sk, 1);
+        generate_commitment_share_lists(&mut OsRng, &p3_sk, 1).unwrap();
     let (p4_public_comshares, mut p4_secret_comshares) =
-        generate_commitment_share_lists(&mut OsRng, &p4_sk, 1);
+        generate_commitment_share_lists(&mut OsRng, &p4_sk, 1).unwrap();
 
     let mut aggregator = SignatureAggregator::new(params, group_key, &message[..]);
 


### PR DESCRIPTION
# Description

This PR removes risks of panic by gently erroring instead.
The two remaining unsanitized `unwrap()` in the DKG phase *can* panic in the case where the participants from which shares are coming from are dealers but aren't signers. We made the distinction in the past when adding the functionality for resharing, but I am not sure we would ever have a scenario where participants can distribute chunks of the group private key without being able to sign from it.

I think it would make more sense to remove this scenario, which would also simplify how things are being done internally. We then would have only two types of participants:
- dealers, who can collectively sign AND redistribute chunks of the group key
- signers, who can ONLY collectively sign

Another approach (more restrictive) would be to consider that participants that can sign should be able to redistribute their secret shares, effectively making no distinction anymore between the two outlined types above.

Fixes #14 

## PR Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added or updated tests that comprehensively prove my change is effective or that my feature works
