### PR TITLE
Apply (most) pedantic lints

### DIFF
--- a/benches/dkg.rs
+++ b/benches/dkg.rs
@@ -96,7 +96,7 @@ fn criterion_benchmark(c: &mut Criterion) {
     participants_states_2.push(
         participants_states_1[0]
             .clone()
-            .to_round_two(&p1_my_encrypted_secret_shares.clone(), rng)
+            .to_round_two(&p1_my_encrypted_secret_shares, rng)
             .unwrap(),
     );
 

--- a/benches/sign.rs
+++ b/benches/sign.rs
@@ -126,14 +126,14 @@ fn criterion_benchmark(c: &mut Criterion) {
     let mut participants_secret_comshares =
         Vec::<SecretCommShareList>::with_capacity(NUMBER_OF_PARTICIPANTS as usize);
     let (p1_public_comshares, p1_secret_comshares) =
-        generate_commitment_share_lists(&mut OsRng, &participants_secret_keys[0].clone(), 1);
+        generate_commitment_share_lists(&mut OsRng, &participants_secret_keys[0], 1);
     participants_public_comshares.push(p1_public_comshares);
     participants_secret_comshares.push(p1_secret_comshares.clone());
 
     for i in 1..THRESHOLD_OF_PARTICIPANTS + 1 {
         let (pi_public_comshares, pi_secret_comshares) = generate_commitment_share_lists(
             &mut OsRng,
-            &participants_secret_keys[(i - 1) as usize].clone(),
+            &participants_secret_keys[(i - 1) as usize],
             1,
         );
         participants_public_comshares.push(pi_public_comshares);

--- a/benches/sign.rs
+++ b/benches/sign.rs
@@ -38,7 +38,7 @@ fn criterion_benchmark(c: &mut Criterion) {
     let mut dh_secret_keys = Vec::<DHSkey>::with_capacity(NUMBER_OF_PARTICIPANTS as usize);
 
     for i in 1..NUMBER_OF_PARTICIPANTS + 1 {
-        let (p, c, dh_sk) = ParticipantDKG::new_dealer(&params, i, rng).unwrap();
+        let (p, c, dh_sk) = ParticipantDKG::new_dealer(params, i, rng).unwrap();
         participants.push(p);
         coefficients.push(c);
         dh_secret_keys.push(dh_sk);
@@ -54,9 +54,9 @@ fn criterion_benchmark(c: &mut Criterion) {
 
     for i in 0..NUMBER_OF_PARTICIPANTS {
         let (pi_state, _participant_lists) = Dkg::<_>::bootstrap(
-            &params,
+            params,
             &dh_secret_keys[i as usize],
-            &participants[i as usize].index.clone(),
+            participants[i as usize].index,
             &coefficients[i as usize],
             &participants,
             rng,
@@ -78,7 +78,7 @@ fn criterion_benchmark(c: &mut Criterion) {
     participants_states_2.push(
         participants_states_1[0]
             .clone()
-            .to_round_two(p1_my_encrypted_secret_shares, rng)
+            .to_round_two(&p1_my_encrypted_secret_shares, rng)
             .unwrap(),
     );
 
@@ -95,7 +95,7 @@ fn criterion_benchmark(c: &mut Criterion) {
         participants_states_2.push(
             participants_states_1[(i - 1) as usize]
                 .clone()
-                .to_round_two(pi_my_encrypted_secret_shares, rng)
+                .to_round_two(&pi_my_encrypted_secret_shares, rng)
                 .unwrap(),
         );
     }
@@ -146,12 +146,12 @@ fn criterion_benchmark(c: &mut Criterion) {
         aggregator.include_signer(
             i,
             participants_public_comshares[(i - 1) as usize].commitments[0],
-            (&participants_secret_keys[(i - 1) as usize]).into(),
+            &participants_secret_keys[(i - 1) as usize].to_public(),
         );
     }
 
     let signers = aggregator.get_signers().clone();
-    let message_hash = Secp256k1Sha256::h4(&message[..]).unwrap();
+    let message_hash = Secp256k1Sha256::h4(&message[..]);
     let message_hash_copy = message_hash;
 
     let p1_sk = participants_secret_keys[0].clone();
@@ -166,7 +166,7 @@ fn criterion_benchmark(c: &mut Criterion) {
                 &signers,
             )
             .unwrap();
-        aggregator.include_partial_signature(pi_partial_signature);
+        aggregator.include_partial_signature(&pi_partial_signature);
     }
 
     c.bench_function("Partial signature creation", move |b| {

--- a/src/ciphersuite.rs
+++ b/src/ciphersuite.rs
@@ -8,7 +8,6 @@ use zeroize::Zeroize;
 use ark_ec::CurveGroup;
 
 use crate::utils::{Scalar, String};
-use crate::FrostResult;
 use digest::{Digest, DynDigest};
 
 /// A trait defining the prime-order group of operation and cryptographic hash function details
@@ -49,7 +48,8 @@ pub trait CipherSuite: Copy + Clone + PartialEq + Eq + Debug + Send + Sync + Zer
     ///
     /// It is used to compute the Non-Interactive Zero-Knowledge proofs
     /// of Knowledge of the participants' private keys.
-    fn h0(m: &[u8]) -> FrostResult<Self, Scalar<Self>> {
+    #[must_use]
+    fn h0(m: &[u8]) -> Scalar<Self> {
         crate::utils::hash_to_field::<Self>((Self::context_string() + "nizkpok").as_bytes(), m)
     }
 
@@ -59,7 +59,8 @@ pub trait CipherSuite: Copy + Clone + PartialEq + Eq + Debug + Send + Sync + Zer
     /// concatenated with "rho".
     ///
     /// It is used to compute the binding factor during an ICE-FROST signing session.
-    fn h1(m: &[u8]) -> FrostResult<Self, Scalar<Self>> {
+    #[must_use]
+    fn h1(m: &[u8]) -> Scalar<Self> {
         crate::utils::hash_to_field::<Self>((Self::context_string() + "rho").as_bytes(), m)
     }
 
@@ -69,7 +70,8 @@ pub trait CipherSuite: Copy + Clone + PartialEq + Eq + Debug + Send + Sync + Zer
     /// concatenated with "challenge".
     ///
     /// It is used to compute the binding factor during an ICE-FROST signing session.
-    fn h2(m: &[u8]) -> FrostResult<Self, Scalar<Self>> {
+    #[must_use]
+    fn h2(m: &[u8]) -> Scalar<Self> {
         crate::utils::hash_to_field::<Self>((Self::context_string() + "challenge").as_bytes(), m)
     }
 
@@ -79,7 +81,8 @@ pub trait CipherSuite: Copy + Clone + PartialEq + Eq + Debug + Send + Sync + Zer
     /// concatenated with "nonce".
     ///
     /// It is used to precompute the nonces to be shared during ICE-FROST signing sessions.
-    fn h3(m: &[u8]) -> FrostResult<Self, Scalar<Self>> {
+    #[must_use]
+    fn h3(m: &[u8]) -> Scalar<Self> {
         crate::utils::hash_to_field::<Self>((Self::context_string() + "nonce").as_bytes(), m)
     }
 
@@ -92,7 +95,8 @@ pub trait CipherSuite: Copy + Clone + PartialEq + Eq + Debug + Send + Sync + Zer
     ///
     /// Signers of an ICE-FROST session should use this method to hash the original message
     /// before proceeding to computing their individual partial signatures.
-    fn h4(m: &[u8]) -> FrostResult<Self, Self::HashOutput> {
+    #[must_use]
+    fn h4(m: &[u8]) -> Self::HashOutput {
         crate::utils::hash_to_array::<Self>((Self::context_string() + "message").as_bytes(), m)
     }
 
@@ -102,7 +106,8 @@ pub trait CipherSuite: Copy + Clone + PartialEq + Eq + Debug + Send + Sync + Zer
     /// concatenated with "commitment".
     ///
     /// It is used to hash the group commitment during an ICE-FROST signing session.
-    fn h5(m: &[u8]) -> FrostResult<Self, Self::HashOutput> {
+    #[must_use]
+    fn h5(m: &[u8]) -> Self::HashOutput {
         crate::utils::hash_to_array::<Self>((Self::context_string() + "commitment").as_bytes(), m)
     }
 }

--- a/src/dkg/key_generation.rs
+++ b/src/dkg/key_generation.rs
@@ -66,9 +66,9 @@
 //!
 //! // Alice, Bob, and Carol each generate their secret polynomial coefficients
 //! // and commitments to them, as well as a zero-knowledge proof of a secret key.
-//! let (alice, alice_coeffs, alice_dh_sk) = Participant::new_dealer(&params, 1, &mut rng)?;
-//! let (bob, bob_coeffs, bob_dh_sk) = Participant::new_dealer(&params, 2, &mut rng)?;
-//! let (carol, carol_coeffs, carol_dh_sk) = Participant::new_dealer(&params, 3, &mut rng)?;
+//! let (alice, alice_coeffs, alice_dh_sk) = Participant::new_dealer(params, 1, &mut rng)?;
+//! let (bob, bob_coeffs, bob_dh_sk) = Participant::new_dealer(params, 2, &mut rng)?;
+//! let (carol, carol_coeffs, carol_dh_sk) = Participant::new_dealer(params, 3, &mut rng)?;
 //!
 //! // They send these values to each of the other participants (out of scope
 //! // for this library), or otherwise publish them somewhere.
@@ -88,9 +88,9 @@
 //! let participants: Vec<Participant<Secp256k1Sha256>> = vec![alice.clone(), bob.clone(), carol.clone()];
 //! let (alice_state, participant_lists) =
 //!     DistributedKeyGeneration::<_, Secp256k1Sha256>::bootstrap(
-//!         &params,
+//!         params,
 //!         &alice_dh_sk,
-//!         &alice.index,
+//!         alice.index,
 //!         &alice_coeffs,
 //!         &participants,
 //!         &mut rng,
@@ -106,9 +106,9 @@
 //! // Bob enters round one of the distributed key generation protocol.
 //! let (bob_state, participant_lists) =
 //!     DistributedKeyGeneration::<_, Secp256k1Sha256>::bootstrap(
-//!         &params,
+//!         params,
 //!         &bob_dh_sk,
-//!         &bob.index,
+//!         bob.index,
 //!         &bob_coeffs,
 //!         &participants,
 //!         &mut rng,
@@ -124,9 +124,9 @@
 //! // Carol enters round one of the distributed key generation protocol.
 //! let (carol_state, participant_lists) =
 //!     DistributedKeyGeneration::<_, Secp256k1Sha256>::bootstrap(
-//!         &params,
+//!         params,
 //!         &carol_dh_sk,
-//!         &carol.index,
+//!         carol.index,
 //!         &carol_coeffs,
 //!         &participants,
 //!         &mut rng,
@@ -158,9 +158,9 @@
 //!
 //! // The participants then use these secret shares from the other participants to advance to
 //! // round two of the distributed key generation protocol.
-//! let alice_state = alice_state.to_round_two(alice_my_encrypted_secret_shares, &mut rng)?;
-//! let bob_state = bob_state.to_round_two(bob_my_encrypted_secret_shares, &mut rng)?;
-//! let carol_state = carol_state.to_round_two(carol_my_encrypted_secret_shares, &mut rng)?;
+//! let alice_state = alice_state.to_round_two(&alice_my_encrypted_secret_shares, &mut rng)?;
+//! let bob_state = bob_state.to_round_two(&bob_my_encrypted_secret_shares, &mut rng)?;
+//! let carol_state = carol_state.to_round_two(&carol_my_encrypted_secret_shares, &mut rng)?;
 //!
 //! // Each participant can now derive their long-lived secret keys and the group's
 //! // public key.
@@ -204,9 +204,9 @@
 //!
 //! // Alice, Bob, and Carol each generate their secret polynomial coefficients
 //! // and commitments to them, as well as a zero-knowledge proof of a secret key.
-//! let (alice, alice_coeffs, alice_dh_sk) = Participant::new_dealer(&params, 1, &mut rng)?;
-//! let (bob, bob_coeffs, bob_dh_sk) = Participant::new_dealer(&params, 2, &mut rng)?;
-//! let (carol, carol_coeffs, carol_dh_sk) = Participant::new_dealer(&params, 3, &mut rng)?;
+//! let (alice, alice_coeffs, alice_dh_sk) = Participant::new_dealer(params, 1, &mut rng)?;
+//! let (bob, bob_coeffs, bob_dh_sk) = Participant::new_dealer(params, 2, &mut rng)?;
+//! let (carol, carol_coeffs, carol_dh_sk) = Participant::new_dealer(params, 3, &mut rng)?;
 //!
 //! // They send these values to each of the other participants (out of scope
 //! // for this library), or otherwise publish them somewhere.
@@ -225,9 +225,9 @@
 //! let participants: Vec<Participant<Secp256k1Sha256>> = vec![alice.clone(), bob.clone(), carol.clone()];
 //! let (alice_state, participant_lists) =
 //!     DistributedKeyGeneration::<_, Secp256k1Sha256>::bootstrap(
-//!         &params,
+//!         params,
 //!         &alice_dh_sk,
-//!         &alice.index,
+//!         alice.index,
 //!         &alice_coeffs,
 //!         &participants,
 //!         &mut rng,
@@ -243,9 +243,9 @@
 //! // Bob enters round one of the distributed key generation protocol.
 //! let (bob_state, participant_lists) =
 //!     DistributedKeyGeneration::<_, Secp256k1Sha256>::bootstrap(
-//!         &params,
+//!         params,
 //!         &bob_dh_sk,
-//!         &bob.index,
+//!         bob.index,
 //!         &bob_coeffs,
 //!         &participants,
 //!         &mut rng,
@@ -261,9 +261,9 @@
 //! // Carol enters round one of the distributed key generation protocol.
 //! let (carol_state, participant_lists) =
 //!     DistributedKeyGeneration::<_, Secp256k1Sha256>::bootstrap(
-//!         &params,
+//!         params,
 //!         &carol_dh_sk,
-//!         &carol.index,
+//!         carol.index,
 //!         &carol_coeffs,
 //!         &participants,
 //!         &mut rng,
@@ -295,9 +295,9 @@
 //!
 //! // The participants then use these secret shares from the other participants to advance to
 //! // round two of the distributed key generation protocol.
-//! let alice_state = alice_state.to_round_two(alice_my_encrypted_secret_shares, &mut rng)?;
-//! let bob_state = bob_state.to_round_two(bob_my_encrypted_secret_shares, &mut rng)?;
-//! let carol_state = carol_state.to_round_two(carol_my_encrypted_secret_shares, &mut rng)?;
+//! let alice_state = alice_state.to_round_two(&alice_my_encrypted_secret_shares, &mut rng)?;
+//! let bob_state = bob_state.to_round_two(&bob_my_encrypted_secret_shares, &mut rng)?;
+//! let carol_state = carol_state.to_round_two(&carol_my_encrypted_secret_shares, &mut rng)?;
 //!
 //! // Each participant can now derive their long-lived secret keys and the group's
 //! // public key.
@@ -314,10 +314,10 @@
 //!
 //! // Alexis, Barbara, Claire and David each generate their Diffie-Hellman
 //! // private key, as well as a zero-knowledge proof to it.
-//! let (alexis, alexis_dh_sk) = Participant::new_signer(&new_params, 1, &mut rng)?;
-//! let (barbara, barbara_dh_sk) = Participant::new_signer(&new_params, 2, &mut rng)?;
-//! let (claire, claire_dh_sk) = Participant::new_signer(&new_params, 3, &mut rng)?;
-//! let (david, david_dh_sk) = Participant::new_signer(&new_params, 4, &mut rng)?;
+//! let (alexis, alexis_dh_sk) = Participant::new_signer(new_params, 1, &mut rng)?;
+//! let (barbara, barbara_dh_sk) = Participant::new_signer(new_params, 2, &mut rng)?;
+//! let (claire, claire_dh_sk) = Participant::new_signer(new_params, 3, &mut rng)?;
+//! let (david, david_dh_sk) = Participant::new_signer(new_params, 4, &mut rng)?;
 //!
 //! // They send these values to each of the other and previous participants
 //! // (out of scope for this library), or otherwise publish them somewhere.
@@ -359,13 +359,13 @@
 //! let signers: Vec<Participant<Secp256k1Sha256>> =
 //!     vec![alexis.clone(), barbara.clone(), claire.clone(), david.clone()];
 //! let (alice_as_dealer, alice_encrypted_shares, participant_lists) =
-//!     Participant::reshare(&new_params, alice_secret_key, &signers, &mut rng)?;
+//!     Participant::reshare(new_params, &alice_secret_key, &signers, &mut rng)?;
 //!
 //! let (bob_as_dealer, bob_encrypted_shares, participant_lists) =
-//!     Participant::reshare(&new_params, bob_secret_key, &signers, &mut rng)?;
+//!     Participant::reshare(new_params, &bob_secret_key, &signers, &mut rng)?;
 //!
 //! let (carol_as_dealer, carol_encrypted_shares, participant_lists) =
-//!     Participant::reshare(&new_params, carol_secret_key, &signers, &mut rng)?;
+//!     Participant::reshare(new_params, &carol_secret_key, &signers, &mut rng)?;
 //!
 //! // NOTE: They use the *new* configuration parameters (3-out-of-4) when resharing.
 //!
@@ -375,9 +375,9 @@
 //!     vec![alice_as_dealer.clone(), bob_as_dealer.clone(), carol_as_dealer.clone()];
 //! let (alexis_state, participant_lists) =
 //!     DistributedKeyGeneration::<_, Secp256k1Sha256>::new(
-//!         &params,
+//!         params,
 //!         &alexis_dh_sk,
-//!         &alexis.index,
+//!         alexis.index,
 //!         &dealers,
 //!         &mut rng,
 //!     )
@@ -385,9 +385,9 @@
 //!
 //! let (barbara_state, participant_lists) =
 //!     DistributedKeyGeneration::<_, Secp256k1Sha256>::new(
-//!         &params,
+//!         params,
 //!         &barbara_dh_sk,
-//!         &barbara.index,
+//!         barbara.index,
 //!         &dealers,
 //!         &mut rng,
 //!     )
@@ -395,9 +395,9 @@
 //!
 //! let (claire_state, participant_lists) =
 //!     DistributedKeyGeneration::<_, Secp256k1Sha256>::new(
-//!         &params,
+//!         params,
 //!         &claire_dh_sk,
-//!         &claire.index,
+//!         claire.index,
 //!         &dealers,
 //!         &mut rng,
 //!     )
@@ -405,9 +405,9 @@
 //!
 //! let (david_state, participant_lists) =
 //!     DistributedKeyGeneration::<_, Secp256k1Sha256>::new(
-//!         &params,
+//!         params,
 //!         &david_dh_sk,
-//!         &david.index,
+//!         david.index,
 //!         &dealers,
 //!         &mut rng,
 //!     )
@@ -447,10 +447,10 @@
 //! // DKG ran by Alice, Bob and Carol. The final group key of the 3-out-of-4 threshold scheme
 //! // configuration will be identical to the one of the 2-out-of-3 original one.
 //!
-//! let alexis_state = alexis_state.to_round_two(alexis_my_encrypted_secret_shares, &mut rng)?;
-//! let barbara_state = barbara_state.to_round_two(barbara_my_encrypted_secret_shares, &mut rng)?;
-//! let claire_state = claire_state.to_round_two(claire_my_encrypted_secret_shares, &mut rng)?;
-//! let david_state = david_state.to_round_two(david_my_encrypted_secret_shares, &mut rng)?;
+//! let alexis_state = alexis_state.to_round_two(&alexis_my_encrypted_secret_shares, &mut rng)?;
+//! let barbara_state = barbara_state.to_round_two(&barbara_my_encrypted_secret_shares, &mut rng)?;
+//! let claire_state = claire_state.to_round_two(&claire_my_encrypted_secret_shares, &mut rng)?;
+//! let david_state = david_state.to_round_two(&david_my_encrypted_secret_shares, &mut rng)?;
 //!
 //! let (alexis_group_key, alexis_secret_key) = alexis_state.finish()?;
 //! let (barbara_group_key, barbara_secret_key) = barbara_state.finish()?;
@@ -621,9 +621,9 @@ impl<C: CipherSuite> DistributedKeyGeneration<RoundOne, C> {
     /// all of the zero-knowledge proofs verified successfully, otherwise a
     /// vector of participants whose proofs were incorrect.
     pub fn bootstrap(
-        parameters: &ThresholdParameters<C>,
+        parameters: ThresholdParameters<C>,
         dh_private_key: &DiffieHellmanPrivateKey<C>,
-        my_index: &u32,
+        my_index: u32,
         my_coefficients: &Coefficients<C>,
         participants: &[Participant<C>],
         mut rng: impl RngCore + CryptoRng,
@@ -663,9 +663,9 @@ impl<C: CipherSuite> DistributedKeyGeneration<RoundOne, C> {
     /// all of the zero-knowledge proofs verified successfully, otherwise a
     /// vector of participants whose zero-knowledge proofs were incorrect.
     pub fn new(
-        parameters: &ThresholdParameters<C>,
+        parameters: ThresholdParameters<C>,
         dh_private_key: &DiffieHellmanPrivateKey<C>,
-        my_index: &u32,
+        my_index: u32,
         dealers: &[Participant<C>],
         mut rng: impl RngCore + CryptoRng,
     ) -> FrostResult<C, (Self, DKGParticipantList<C>)> {
@@ -683,9 +683,9 @@ impl<C: CipherSuite> DistributedKeyGeneration<RoundOne, C> {
 
     #[allow(clippy::too_many_arguments)]
     pub(crate) fn new_state_internal(
-        parameters: &ThresholdParameters<C>,
+        parameters: ThresholdParameters<C>,
         dh_private_key: &DiffieHellmanPrivateKey<C>,
-        my_index: &u32,
+        my_index: u32,
         my_coefficients: Option<&Coefficients<C>>,
         participants: &[Participant<C>],
         from_dealer: bool,
@@ -710,18 +710,15 @@ impl<C: CipherSuite> DistributedKeyGeneration<RoundOne, C> {
         }
 
         // Check the public keys and the DH keys of the participants.
-        for p in participants.iter() {
+        for p in participants {
             // Always check the DH keys of the participants
             match p.proof_of_dh_private_key.verify(p.index, &p.dh_public_key) {
-                Ok(_) => {
+                Ok(()) => {
                     // Signers additionally check the public keys of the signers
                     if from_signer {
-                        let public_key = match p.public_key() {
-                            Some(key) => key,
-                            None => {
-                                misbehaving_participants.push(p.index);
-                                continue;
-                            }
+                        let Some(public_key) = p.public_key() else {
+                            misbehaving_participants.push(p.index);
+                            continue;
                         };
                         match p
                             .proof_of_secret_key
@@ -729,7 +726,7 @@ impl<C: CipherSuite> DistributedKeyGeneration<RoundOne, C> {
                             .unwrap()
                             .verify(p.index, public_key)
                         {
-                            Ok(_) => {
+                            Ok(()) => {
                                 valid_participants.push(p.clone());
                                 their_commitments.push(p.commitments.as_ref().unwrap().clone());
                                 their_dh_public_keys.push((p.index, p.dh_public_key.clone()));
@@ -752,8 +749,8 @@ impl<C: CipherSuite> DistributedKeyGeneration<RoundOne, C> {
 
         if !from_dealer && from_signer {
             let state = ActualState {
-                parameters: *parameters,
-                index: *my_index,
+                parameters,
+                index: my_index,
                 dh_private_key: dh_private_key.clone(),
                 dh_public_key,
                 their_commitments: Some(their_commitments),
@@ -788,9 +785,9 @@ impl<C: CipherSuite> DistributedKeyGeneration<RoundOne, C> {
         let mut their_encrypted_secret_shares: Vec<EncryptedSecretShare<C>> =
             Vec::with_capacity(parameters.n as usize - 1);
 
-        for p in participants.iter() {
+        for p in participants {
             let share =
-                SecretShare::<C>::evaluate_polynomial(my_index, &p.index, my_coefficients.unwrap());
+                SecretShare::<C>::evaluate_polynomial(my_index, p.index, my_coefficients.unwrap());
 
             let dh_key = p.dh_public_key.key * dh_private_key.0;
             let mut dh_key_bytes = Vec::with_capacity(dh_key.compressed_size());
@@ -802,14 +799,14 @@ impl<C: CipherSuite> DistributedKeyGeneration<RoundOne, C> {
         }
 
         let state = ActualState {
-            parameters: *parameters,
-            index: *my_index,
+            parameters,
+            index: my_index,
             dh_private_key: dh_private_key.clone(),
             dh_public_key,
-            their_commitments: if !from_signer {
-                None
-            } else {
+            their_commitments: if from_signer {
                 Some(their_commitments)
+            } else {
+                None
             },
             their_dh_public_keys,
             their_encrypted_secret_shares: Some(their_encrypted_secret_shares),
@@ -847,7 +844,7 @@ impl<C: CipherSuite> DistributedKeyGeneration<RoundOne, C> {
     /// participants in turn.
     pub fn to_round_two(
         mut self,
-        my_encrypted_secret_shares: Vec<EncryptedSecretShare<C>>,
+        my_encrypted_secret_shares: &[EncryptedSecretShare<C>],
         mut rng: impl RngCore + CryptoRng,
     ) -> FrostResult<C, DistributedKeyGeneration<RoundTwo, C>> {
         // Sanity check
@@ -868,8 +865,8 @@ impl<C: CipherSuite> DistributedKeyGeneration<RoundOne, C> {
 
         // Step 2.1: Each P_i decrypts their shares with
         //           key k_il = pk_l^sk_i
-        for encrypted_share in my_encrypted_secret_shares.iter() {
-            for pk in self.state.their_dh_public_keys.iter() {
+        for encrypted_share in my_encrypted_secret_shares {
+            for pk in &self.state.their_dh_public_keys {
                 if pk.0 == encrypted_share.sender_index {
                     let dh_shared_key = *pk.1 * self.state.dh_private_key.0;
                     let mut dh_key_bytes = Vec::with_capacity(dh_shared_key.compressed_size());
@@ -883,7 +880,7 @@ impl<C: CipherSuite> DistributedKeyGeneration<RoundOne, C> {
                     let decrypted_share = decrypt_share(encrypted_share, &dh_key_bytes);
                     let decrypted_share_ref = &decrypted_share;
 
-                    for commitment in self.state.their_commitments.as_ref().unwrap().iter() {
+                    for commitment in self.state.their_commitments.as_ref().unwrap() {
                         if commitment.index == encrypted_share.sender_index {
                             // If the decrypted share is incorrect, P_i builds
                             // a complaint
@@ -956,13 +953,13 @@ impl<C: CipherSuite> DistributedKeyGeneration<RoundTwo, C> {
 
         let mut index_vector = Vec::with_capacity(my_secret_shares.len());
 
-        for share in my_secret_shares.iter() {
+        for share in my_secret_shares {
             index_vector.push(share.sender_index);
         }
 
         let mut key = Scalar::<C>::ZERO;
 
-        for share in my_secret_shares.iter() {
+        for share in my_secret_shares {
             let coeff =
                 match calculate_lagrange_coefficients::<C>(share.sender_index, &index_vector) {
                     Ok(s) => s,
@@ -982,21 +979,18 @@ impl<C: CipherSuite> DistributedKeyGeneration<RoundTwo, C> {
     /// # Returns
     ///
     /// A [`GroupVerifyingKey`] for the set of participants.
-    ///
-    /// my_commitment is needed for now, but won't be when the distinction
-    /// dealers/signers is implemented.
     pub(crate) fn calculate_group_key(&self) -> FrostResult<C, GroupVerifyingKey<C>> {
         let mut index_vector =
             Vec::with_capacity(self.state.their_commitments.as_ref().unwrap().len());
 
-        for commitment in self.state.their_commitments.as_ref().unwrap().iter() {
+        for commitment in self.state.their_commitments.as_ref().unwrap() {
             index_vector.push(commitment.index);
         }
 
         let mut group_key = <C as CipherSuite>::G::zero();
 
         // The group key is the interpolation at 0 of all index 0 of the dealers' commitments.
-        for commitment in self.state.their_commitments.as_ref().unwrap().iter() {
+        for commitment in self.state.their_commitments.as_ref().unwrap() {
             let coeff = match calculate_lagrange_coefficients::<C>(commitment.index, &index_vector)
             {
                 Ok(s) => s,
@@ -1024,7 +1018,7 @@ impl<C: CipherSuite> DistributedKeyGeneration<RoundTwo, C> {
             points: Vec::new(),
         };
 
-        for commitment in self.state.their_commitments.as_ref().unwrap().iter() {
+        for commitment in self.state.their_commitments.as_ref().unwrap() {
             if commitment.index == complaint.accused_index {
                 commitment_accused = commitment.clone();
             }
@@ -1034,7 +1028,7 @@ impl<C: CipherSuite> DistributedKeyGeneration<RoundTwo, C> {
             return complaint.maker_index;
         }
 
-        for (index, pk) in self.state.their_dh_public_keys.iter() {
+        for (index, pk) in &self.state.their_dh_public_keys {
             if index == &complaint.maker_index {
                 pk_maker = **pk;
             } else if index == &complaint.accused_index {
@@ -1093,7 +1087,7 @@ mod test {
         let params = ThresholdParameters::new(3, 2);
         let rng = OsRng;
 
-        let (p, _, _) = Participant::<Secp256k1Sha256>::new_dealer(&params, 1, rng).unwrap();
+        let (p, _, _) = Participant::<Secp256k1Sha256>::new_dealer(params, 1, rng).unwrap();
         let result = p
             .proof_of_secret_key
             .as_ref()
@@ -1112,7 +1106,7 @@ mod test {
         }
 
         let coefficients = Coefficients::<Secp256k1Sha256>(coeffs);
-        let share = SecretShare::<Secp256k1Sha256>::evaluate_polynomial(&1, &1, &coefficients);
+        let share = SecretShare::<Secp256k1Sha256>::evaluate_polynomial(1, 1, &coefficients);
 
         assert!(share.polynomial_evaluation == Fr::from(5u8));
 
@@ -1139,7 +1133,7 @@ mod test {
         }
 
         let coefficients = Coefficients::<Secp256k1Sha256>(coeffs);
-        let share = SecretShare::evaluate_polynomial(&1, &0, &coefficients);
+        let share = SecretShare::evaluate_polynomial(1, 0, &coefficients);
 
         assert!(share.polynomial_evaluation == Fr::ONE);
 
@@ -1163,7 +1157,7 @@ mod test {
         let rng = OsRng;
 
         let (p1, p1coeffs, p1_dh_sk) =
-            Participant::<Secp256k1Sha256>::new_dealer(&params, 1, rng).unwrap();
+            Participant::<Secp256k1Sha256>::new_dealer(params, 1, rng).unwrap();
 
         p1.proof_of_secret_key
             .as_ref()
@@ -1174,9 +1168,9 @@ mod test {
         let participants: Vec<Participant<Secp256k1Sha256>> = vec![p1.clone()];
         let (p1_state, _participant_lists) =
             DistributedKeyGeneration::<RoundOne, Secp256k1Sha256>::bootstrap(
-                &params,
+                params,
                 &p1_dh_sk,
-                &p1.index,
+                p1.index,
                 &p1coeffs,
                 &participants,
                 rng,
@@ -1185,7 +1179,7 @@ mod test {
         let p1_my_encrypted_secret_shares =
             p1_state.their_encrypted_secret_shares().unwrap().clone();
         let p1_state = p1_state
-            .to_round_two(p1_my_encrypted_secret_shares, rng)
+            .to_round_two(&p1_my_encrypted_secret_shares, rng)
             .unwrap();
         let result = p1_state.finish();
 
@@ -1202,15 +1196,15 @@ mod test {
         let rng = OsRng;
 
         let (p1, p1coeffs, p1_dh_sk) =
-            Participant::<Secp256k1Sha256>::new_dealer(&params, 1, rng).unwrap();
+            Participant::<Secp256k1Sha256>::new_dealer(params, 1, rng).unwrap();
         let (p2, p2coeffs, p2_dh_sk) =
-            Participant::<Secp256k1Sha256>::new_dealer(&params, 2, rng).unwrap();
+            Participant::<Secp256k1Sha256>::new_dealer(params, 2, rng).unwrap();
         let (p3, p3coeffs, p3_dh_sk) =
-            Participant::<Secp256k1Sha256>::new_dealer(&params, 3, rng).unwrap();
+            Participant::<Secp256k1Sha256>::new_dealer(params, 3, rng).unwrap();
         let (p4, p4coeffs, p4_dh_sk) =
-            Participant::<Secp256k1Sha256>::new_dealer(&params, 4, rng).unwrap();
+            Participant::<Secp256k1Sha256>::new_dealer(params, 4, rng).unwrap();
         let (p5, p5coeffs, p5_dh_sk) =
-            Participant::<Secp256k1Sha256>::new_dealer(&params, 5, rng).unwrap();
+            Participant::<Secp256k1Sha256>::new_dealer(params, 5, rng).unwrap();
 
         p1.proof_of_secret_key
             .as_ref()
@@ -1242,9 +1236,9 @@ mod test {
             vec![p1.clone(), p2.clone(), p3.clone(), p4.clone(), p5.clone()];
         let (p1_state, _participant_lists) =
             DistributedKeyGeneration::<RoundOne, Secp256k1Sha256>::bootstrap(
-                &params,
+                params,
                 &p1_dh_sk,
-                &p1.index,
+                p1.index,
                 &p1coeffs,
                 &participants,
                 rng,
@@ -1254,9 +1248,9 @@ mod test {
 
         let (p2_state, _participant_lists) =
             DistributedKeyGeneration::<RoundOne, Secp256k1Sha256>::bootstrap(
-                &params,
+                params,
                 &p2_dh_sk,
-                &p2.index,
+                p2.index,
                 &p2coeffs,
                 &participants,
                 rng,
@@ -1266,9 +1260,9 @@ mod test {
 
         let (p3_state, _participant_lists) =
             DistributedKeyGeneration::<RoundOne, Secp256k1Sha256>::bootstrap(
-                &params,
+                params,
                 &p3_dh_sk,
-                &p3.index,
+                p3.index,
                 &p3coeffs,
                 &participants,
                 rng,
@@ -1278,9 +1272,9 @@ mod test {
 
         let (p4_state, _participant_lists) =
             DistributedKeyGeneration::<RoundOne, Secp256k1Sha256>::bootstrap(
-                &params,
+                params,
                 &p4_dh_sk,
-                &p4.index,
+                p4.index,
                 &p4coeffs,
                 &participants,
                 rng,
@@ -1290,9 +1284,9 @@ mod test {
 
         let (p5_state, _participant_lists) =
             DistributedKeyGeneration::<RoundOne, Secp256k1Sha256>::bootstrap(
-                &params,
+                params,
                 &p5_dh_sk,
-                &p5.index,
+                p5.index,
                 &p5coeffs,
                 &participants,
                 rng,
@@ -1341,19 +1335,19 @@ mod test {
         ];
 
         let p1_state = p1_state
-            .to_round_two(p1_my_encrypted_secret_shares, rng)
+            .to_round_two(&p1_my_encrypted_secret_shares, rng)
             .unwrap();
         let p2_state = p2_state
-            .to_round_two(p2_my_encrypted_secret_shares, rng)
+            .to_round_two(&p2_my_encrypted_secret_shares, rng)
             .unwrap();
         let p3_state = p3_state
-            .to_round_two(p3_my_encrypted_secret_shares, rng)
+            .to_round_two(&p3_my_encrypted_secret_shares, rng)
             .unwrap();
         let p4_state = p4_state
-            .to_round_two(p4_my_encrypted_secret_shares, rng)
+            .to_round_two(&p4_my_encrypted_secret_shares, rng)
             .unwrap();
         let p5_state = p5_state
-            .to_round_two(p5_my_encrypted_secret_shares, rng)
+            .to_round_two(&p5_my_encrypted_secret_shares, rng)
             .unwrap();
 
         let (p1_group_key, p1_secret_key) = p1_state.finish().unwrap();
@@ -1388,7 +1382,7 @@ mod test {
 
         let group_key = GroupVerifyingKey::new(Projective::generator().mul(group_secret_key));
 
-        assert!(p5_group_key == group_key)
+        assert!(p5_group_key == group_key);
     }
 
     #[test]
@@ -1398,11 +1392,11 @@ mod test {
             let rng = OsRng;
 
             let (p1, p1coeffs, p1_dh_sk) =
-                Participant::<Secp256k1Sha256>::new_dealer(&params, 1, rng).unwrap();
+                Participant::<Secp256k1Sha256>::new_dealer(params, 1, rng).unwrap();
             let (p2, p2coeffs, p2_dh_sk) =
-                Participant::<Secp256k1Sha256>::new_dealer(&params, 2, rng).unwrap();
+                Participant::<Secp256k1Sha256>::new_dealer(params, 2, rng).unwrap();
             let (p3, p3coeffs, p3_dh_sk) =
-                Participant::<Secp256k1Sha256>::new_dealer(&params, 3, rng).unwrap();
+                Participant::<Secp256k1Sha256>::new_dealer(params, 3, rng).unwrap();
 
             p1.proof_of_secret_key
                 .as_ref()
@@ -1421,9 +1415,9 @@ mod test {
                 vec![p1.clone(), p2.clone(), p3.clone()];
             let (p1_state, _participant_lists) =
                 DistributedKeyGeneration::<RoundOne, Secp256k1Sha256>::bootstrap(
-                    &params,
+                    params,
                     &p1_dh_sk,
-                    &p1.index,
+                    p1.index,
                     &p1coeffs,
                     &participants,
                     rng,
@@ -1432,9 +1426,9 @@ mod test {
 
             let (p2_state, _participant_lists) =
                 DistributedKeyGeneration::<RoundOne, Secp256k1Sha256>::bootstrap(
-                    &params,
+                    params,
                     &p2_dh_sk,
-                    &p2.index,
+                    p2.index,
                     &p2coeffs,
                     &participants,
                     rng,
@@ -1443,9 +1437,9 @@ mod test {
 
             let (p3_state, _participant_lists) =
                 DistributedKeyGeneration::<RoundOne, Secp256k1Sha256>::bootstrap(
-                    &params,
+                    params,
                     &p3_dh_sk,
-                    &p3.index,
+                    p3.index,
                     &p3coeffs,
                     &participants,
                     rng,
@@ -1468,9 +1462,9 @@ mod test {
                 p3_their_encrypted_secret_shares[2].clone(),
             ];
 
-            let p1_state = p1_state.to_round_two(p1_my_encrypted_secret_shares, rng)?;
-            let p2_state = p2_state.to_round_two(p2_my_encrypted_secret_shares, rng)?;
-            let p3_state = p3_state.to_round_two(p3_my_encrypted_secret_shares, rng)?;
+            let p1_state = p1_state.to_round_two(&p1_my_encrypted_secret_shares, rng)?;
+            let p2_state = p2_state.to_round_two(&p2_my_encrypted_secret_shares, rng)?;
+            let p3_state = p3_state.to_round_two(&p3_my_encrypted_secret_shares, rng)?;
 
             let (p1_group_key, _p1_secret_key) = p1_state.finish()?;
             let (p2_group_key, _p2_secret_key) = p2_state.finish()?;
@@ -1491,11 +1485,11 @@ mod test {
             let rng = OsRng;
 
             let (dealer1, dealer1coeffs, dealer1_dh_sk) =
-                Participant::<Secp256k1Sha256>::new_dealer(&params, 1, rng).unwrap();
+                Participant::<Secp256k1Sha256>::new_dealer(params, 1, rng).unwrap();
             let (dealer2, dealer2coeffs, dealer2_dh_sk) =
-                Participant::<Secp256k1Sha256>::new_dealer(&params, 2, rng).unwrap();
+                Participant::<Secp256k1Sha256>::new_dealer(params, 2, rng).unwrap();
             let (dealer3, dealer3coeffs, dealer3_dh_sk) =
-                Participant::<Secp256k1Sha256>::new_dealer(&params, 3, rng).unwrap();
+                Participant::<Secp256k1Sha256>::new_dealer(params, 3, rng).unwrap();
 
             dealer1
                 .proof_of_secret_key
@@ -1517,9 +1511,9 @@ mod test {
                 vec![dealer1.clone(), dealer2.clone(), dealer3.clone()];
             let (dealer1_state, _participant_lists) =
                 DistributedKeyGeneration::<RoundOne, Secp256k1Sha256>::bootstrap(
-                    &params,
+                    params,
                     &dealer1_dh_sk,
-                    &dealer1.index,
+                    dealer1.index,
                     &dealer1coeffs,
                     &dealers,
                     rng,
@@ -1529,9 +1523,9 @@ mod test {
 
             let (dealer2_state, _participant_lists) =
                 DistributedKeyGeneration::<RoundOne, Secp256k1Sha256>::bootstrap(
-                    &params,
+                    params,
                     &dealer2_dh_sk,
-                    &dealer2.index,
+                    dealer2.index,
                     &dealer2coeffs,
                     &dealers,
                     rng,
@@ -1541,9 +1535,9 @@ mod test {
 
             let (dealer3_state, _participant_lists) =
                 DistributedKeyGeneration::<RoundOne, Secp256k1Sha256>::bootstrap(
-                    &params,
+                    params,
                     &dealer3_dh_sk,
-                    &dealer3.index,
+                    dealer3.index,
                     &dealer3coeffs,
                     &dealers,
                     rng,
@@ -1568,11 +1562,11 @@ mod test {
             ];
 
             let dealer1_state =
-                dealer1_state.to_round_two(dealer1_my_encrypted_secret_shares, rng)?;
+                dealer1_state.to_round_two(&dealer1_my_encrypted_secret_shares, rng)?;
             let dealer2_state =
-                dealer2_state.to_round_two(dealer2_my_encrypted_secret_shares, rng)?;
+                dealer2_state.to_round_two(&dealer2_my_encrypted_secret_shares, rng)?;
             let dealer3_state =
-                dealer3_state.to_round_two(dealer3_my_encrypted_secret_shares, rng)?;
+                dealer3_state.to_round_two(&dealer3_my_encrypted_secret_shares, rng)?;
 
             let (dealer1_group_key, dealer1_secret_key) = dealer1_state.finish()?;
             let (dealer2_group_key, dealer2_secret_key) = dealer2_state.finish()?;
@@ -1581,8 +1575,8 @@ mod test {
             assert!(dealer1_group_key == dealer2_group_key);
             assert!(dealer2_group_key == dealer3_group_key);
 
-            let (signer1, signer1_dh_sk) = Participant::new_signer(&params, 1, rng).unwrap();
-            let (signer2, signer2_dh_sk) = Participant::new_signer(&params, 2, rng).unwrap();
+            let (signer1, signer1_dh_sk) = Participant::new_signer(params, 1, rng).unwrap();
+            let (signer2, signer2_dh_sk) = Participant::new_signer(params, 2, rng).unwrap();
             // Dealer 3 is also a participant of the next set of signers
             let (signer3, signer3_dh_sk) = (dealer3, dealer3_dh_sk);
 
@@ -1590,11 +1584,11 @@ mod test {
                 vec![signer1.clone(), signer2.clone(), signer3.clone()];
 
             let (dealer1_for_signers, dealer1_encrypted_shares_for_signers, _participant_lists) =
-                Participant::reshare(&params, dealer1_secret_key, &signers, rng)?;
+                Participant::reshare(params, &dealer1_secret_key, &signers, rng)?;
             let (dealer2_for_signers, dealer2_encrypted_shares_for_signers, _participant_lists) =
-                Participant::reshare(&params, dealer2_secret_key, &signers, rng)?;
+                Participant::reshare(params, &dealer2_secret_key, &signers, rng)?;
             let (dealer3_for_signers, dealer3_encrypted_shares_for_signers, _participant_lists) =
-                Participant::reshare(&params, dealer3_secret_key, &signers, rng)?;
+                Participant::reshare(params, &dealer3_secret_key, &signers, rng)?;
 
             let dealers: Vec<Participant<Secp256k1Sha256>> = vec![
                 dealer1_for_signers,
@@ -1603,27 +1597,27 @@ mod test {
             ];
             let (signer1_state, _participant_lists) =
                 DistributedKeyGeneration::<RoundOne, Secp256k1Sha256>::new(
-                    &params,
+                    params,
                     &signer1_dh_sk,
-                    &signer1.index,
+                    signer1.index,
                     &dealers,
                     rng,
                 )?;
 
             let (signer2_state, _participant_lists) =
                 DistributedKeyGeneration::<RoundOne, Secp256k1Sha256>::new(
-                    &params,
+                    params,
                     &signer2_dh_sk,
-                    &signer2.index,
+                    signer2.index,
                     &dealers,
                     rng,
                 )?;
 
             let (signer3_state, _participant_lists) =
                 DistributedKeyGeneration::<RoundOne, Secp256k1Sha256>::new(
-                    &params,
+                    params,
                     &signer3_dh_sk,
-                    &signer3.index,
+                    signer3.index,
                     &dealers,
                     rng,
                 )?;
@@ -1645,11 +1639,11 @@ mod test {
             ];
 
             let signer1_state =
-                signer1_state.to_round_two(signer1_my_encrypted_secret_shares, rng)?;
+                signer1_state.to_round_two(&signer1_my_encrypted_secret_shares, rng)?;
             let signer2_state =
-                signer2_state.to_round_two(signer2_my_encrypted_secret_shares, rng)?;
+                signer2_state.to_round_two(&signer2_my_encrypted_secret_shares, rng)?;
             let signer3_state =
-                signer3_state.to_round_two(signer3_my_encrypted_secret_shares, rng)?;
+                signer3_state.to_round_two(&signer3_my_encrypted_secret_shares, rng)?;
 
             let (signer1_group_key, _signer1_secret_key) = signer1_state.finish()?;
             let (signer2_group_key, _signer2_secret_key) = signer2_state.finish()?;
@@ -1672,11 +1666,11 @@ mod test {
             let rng = OsRng;
 
             let (dealer1, dealer1coeffs, dealer1_dh_sk) =
-                Participant::<Secp256k1Sha256>::new_dealer(&params_dealers, 1, rng).unwrap();
+                Participant::<Secp256k1Sha256>::new_dealer(params_dealers, 1, rng).unwrap();
             let (dealer2, dealer2coeffs, dealer2_dh_sk) =
-                Participant::<Secp256k1Sha256>::new_dealer(&params_dealers, 2, rng).unwrap();
+                Participant::<Secp256k1Sha256>::new_dealer(params_dealers, 2, rng).unwrap();
             let (dealer3, dealer3coeffs, dealer3_dh_sk) =
-                Participant::<Secp256k1Sha256>::new_dealer(&params_dealers, 3, rng).unwrap();
+                Participant::<Secp256k1Sha256>::new_dealer(params_dealers, 3, rng).unwrap();
 
             dealer1
                 .proof_of_secret_key
@@ -1698,9 +1692,9 @@ mod test {
                 vec![dealer1.clone(), dealer2.clone(), dealer3.clone()];
             let (dealer1_state, _participant_lists) =
                 DistributedKeyGeneration::<RoundOne, Secp256k1Sha256>::bootstrap(
-                    &params_dealers,
+                    params_dealers,
                     &dealer1_dh_sk,
-                    &dealer1.index,
+                    dealer1.index,
                     &dealer1coeffs,
                     &dealers,
                     rng,
@@ -1710,9 +1704,9 @@ mod test {
 
             let (dealer2_state, _participant_lists) =
                 DistributedKeyGeneration::<RoundOne, Secp256k1Sha256>::bootstrap(
-                    &params_dealers,
+                    params_dealers,
                     &dealer2_dh_sk,
-                    &dealer2.index,
+                    dealer2.index,
                     &dealer2coeffs,
                     &dealers,
                     rng,
@@ -1722,9 +1716,9 @@ mod test {
 
             let (dealer3_state, _participant_lists) =
                 DistributedKeyGeneration::<RoundOne, Secp256k1Sha256>::bootstrap(
-                    &params_dealers,
+                    params_dealers,
                     &dealer3_dh_sk,
-                    &dealer3.index,
+                    dealer3.index,
                     &dealer3coeffs,
                     &dealers,
                     rng,
@@ -1749,11 +1743,11 @@ mod test {
             ];
 
             let dealer1_state =
-                dealer1_state.to_round_two(dealer1_my_encrypted_secret_shares, rng)?;
+                dealer1_state.to_round_two(&dealer1_my_encrypted_secret_shares, rng)?;
             let dealer2_state =
-                dealer2_state.to_round_two(dealer2_my_encrypted_secret_shares, rng)?;
+                dealer2_state.to_round_two(&dealer2_my_encrypted_secret_shares, rng)?;
             let dealer3_state =
-                dealer3_state.to_round_two(dealer3_my_encrypted_secret_shares, rng)?;
+                dealer3_state.to_round_two(&dealer3_my_encrypted_secret_shares, rng)?;
 
             let (dealer1_group_key, dealer1_secret_key) = dealer1_state.finish()?;
             let (dealer2_group_key, dealer2_secret_key) = dealer2_state.finish()?;
@@ -1763,16 +1757,11 @@ mod test {
             assert!(dealer2_group_key == dealer3_group_key);
 
             let params_signers = ThresholdParameters::<Secp256k1Sha256>::new(5, 3);
-            let (signer1, signer1_dh_sk) =
-                Participant::new_signer(&params_signers, 1, rng).unwrap();
-            let (signer2, signer2_dh_sk) =
-                Participant::new_signer(&params_signers, 2, rng).unwrap();
-            let (signer3, signer3_dh_sk) =
-                Participant::new_signer(&params_signers, 3, rng).unwrap();
-            let (signer4, signer4_dh_sk) =
-                Participant::new_signer(&params_signers, 4, rng).unwrap();
-            let (signer5, signer5_dh_sk) =
-                Participant::new_signer(&params_signers, 5, rng).unwrap();
+            let (signer1, signer1_dh_sk) = Participant::new_signer(params_signers, 1, rng).unwrap();
+            let (signer2, signer2_dh_sk) = Participant::new_signer(params_signers, 2, rng).unwrap();
+            let (signer3, signer3_dh_sk) = Participant::new_signer(params_signers, 3, rng).unwrap();
+            let (signer4, signer4_dh_sk) = Participant::new_signer(params_signers, 4, rng).unwrap();
+            let (signer5, signer5_dh_sk) = Participant::new_signer(params_signers, 5, rng).unwrap();
 
             let signers: Vec<Participant<Secp256k1Sha256>> = vec![
                 signer1.clone(),
@@ -1783,11 +1772,11 @@ mod test {
             ];
 
             let (dealer1_for_signers, dealer1_encrypted_shares_for_signers, _participant_lists) =
-                Participant::reshare(&params_signers, dealer1_secret_key, &signers, rng)?;
+                Participant::reshare(params_signers, &dealer1_secret_key, &signers, rng)?;
             let (dealer2_for_signers, dealer2_encrypted_shares_for_signers, _participant_lists) =
-                Participant::reshare(&params_signers, dealer2_secret_key, &signers, rng)?;
+                Participant::reshare(params_signers, &dealer2_secret_key, &signers, rng)?;
             let (dealer3_for_signers, dealer3_encrypted_shares_for_signers, _participant_lists) =
-                Participant::reshare(&params_signers, dealer3_secret_key, &signers, rng)?;
+                Participant::reshare(params_signers, &dealer3_secret_key, &signers, rng)?;
 
             let dealers: Vec<Participant<Secp256k1Sha256>> = vec![
                 dealer1_for_signers,
@@ -1796,45 +1785,45 @@ mod test {
             ];
             let (signer1_state, _participant_lists) =
                 DistributedKeyGeneration::<RoundOne, Secp256k1Sha256>::new(
-                    &params_dealers,
+                    params_dealers,
                     &signer1_dh_sk,
-                    &signer1.index,
+                    signer1.index,
                     &dealers,
                     rng,
                 )?;
 
             let (signer2_state, _participant_lists) =
                 DistributedKeyGeneration::<RoundOne, Secp256k1Sha256>::new(
-                    &params_dealers,
+                    params_dealers,
                     &signer2_dh_sk,
-                    &signer2.index,
+                    signer2.index,
                     &dealers,
                     rng,
                 )?;
 
             let (signer3_state, _participant_lists) =
                 DistributedKeyGeneration::<RoundOne, Secp256k1Sha256>::new(
-                    &params_dealers,
+                    params_dealers,
                     &signer3_dh_sk,
-                    &signer3.index,
+                    signer3.index,
                     &dealers,
                     rng,
                 )?;
 
             let (signer4_state, _participant_lists) =
                 DistributedKeyGeneration::<RoundOne, Secp256k1Sha256>::new(
-                    &params_dealers,
+                    params_dealers,
                     &signer4_dh_sk,
-                    &signer4.index,
+                    signer4.index,
                     &dealers,
                     rng,
                 )?;
 
             let (signer5_state, _participant_lists) =
                 DistributedKeyGeneration::<RoundOne, Secp256k1Sha256>::new(
-                    &params_dealers,
+                    params_dealers,
                     &signer5_dh_sk,
-                    &signer5.index,
+                    signer5.index,
                     &dealers,
                     rng,
                 )?;
@@ -1866,15 +1855,15 @@ mod test {
             ];
 
             let signer1_state =
-                signer1_state.to_round_two(signer1_my_encrypted_secret_shares, rng)?;
+                signer1_state.to_round_two(&signer1_my_encrypted_secret_shares, rng)?;
             let signer2_state =
-                signer2_state.to_round_two(signer2_my_encrypted_secret_shares, rng)?;
+                signer2_state.to_round_two(&signer2_my_encrypted_secret_shares, rng)?;
             let signer3_state =
-                signer3_state.to_round_two(signer3_my_encrypted_secret_shares, rng)?;
+                signer3_state.to_round_two(&signer3_my_encrypted_secret_shares, rng)?;
             let signer4_state =
-                signer4_state.to_round_two(signer4_my_encrypted_secret_shares, rng)?;
+                signer4_state.to_round_two(&signer4_my_encrypted_secret_shares, rng)?;
             let signer5_state =
-                signer5_state.to_round_two(signer5_my_encrypted_secret_shares, rng)?;
+                signer5_state.to_round_two(&signer5_my_encrypted_secret_shares, rng)?;
 
             let (signer1_group_key, _signer1_secret_key) = signer1_state.finish()?;
             let (signer2_group_key, _signer2_secret_key) = signer2_state.finish()?;
@@ -1923,11 +1912,11 @@ mod test {
             let rng = OsRng;
 
             let (p1, p1coeffs, dh_sk1) =
-                Participant::<Secp256k1Sha256>::new_dealer(&params, 1, rng).unwrap();
+                Participant::<Secp256k1Sha256>::new_dealer(params, 1, rng).unwrap();
             let (p2, p2coeffs, dh_sk2) =
-                Participant::<Secp256k1Sha256>::new_dealer(&params, 2, rng).unwrap();
+                Participant::<Secp256k1Sha256>::new_dealer(params, 2, rng).unwrap();
             let (p3, p3coeffs, dh_sk3) =
-                Participant::<Secp256k1Sha256>::new_dealer(&params, 3, rng).unwrap();
+                Participant::<Secp256k1Sha256>::new_dealer(params, 3, rng).unwrap();
 
             p1.proof_of_secret_key
                 .as_ref()
@@ -1946,9 +1935,9 @@ mod test {
                 vec![p1.clone(), p2.clone(), p3.clone()];
             let (p1_state, _participant_lists) =
                 DistributedKeyGeneration::<RoundOne, Secp256k1Sha256>::bootstrap(
-                    &params,
+                    params,
                     &dh_sk1,
-                    &p1.index,
+                    p1.index,
                     &p1coeffs,
                     &participants,
                     rng,
@@ -1957,9 +1946,9 @@ mod test {
 
             let (p2_state, _participant_lists) =
                 DistributedKeyGeneration::<RoundOne, Secp256k1Sha256>::bootstrap(
-                    &params,
+                    params,
                     &dh_sk2,
-                    &p2.index,
+                    p2.index,
                     &p2coeffs,
                     &participants,
                     rng,
@@ -1968,9 +1957,9 @@ mod test {
 
             let (p3_state, _participant_lists) =
                 DistributedKeyGeneration::<RoundOne, Secp256k1Sha256>::bootstrap(
-                    &params,
+                    params,
                     &dh_sk3,
-                    &p3.index,
+                    p3.index,
                     &p3coeffs,
                     &participants,
                     rng,
@@ -1993,9 +1982,9 @@ mod test {
                 p3_their_encrypted_secret_shares[2].clone(),
             ];
 
-            let p1_state = p1_state.to_round_two(p1_my_encrypted_secret_shares, rng)?;
-            let p2_state = p2_state.to_round_two(p2_my_encrypted_secret_shares, rng)?;
-            let p3_state = p3_state.to_round_two(p3_my_encrypted_secret_shares, rng)?;
+            let p1_state = p1_state.to_round_two(&p1_my_encrypted_secret_shares, rng)?;
+            let p2_state = p2_state.to_round_two(&p2_my_encrypted_secret_shares, rng)?;
+            let p3_state = p3_state.to_round_two(&p3_my_encrypted_secret_shares, rng)?;
 
             let (p1_group_key, _p1_secret_key) = p1_state.finish()?;
             let (p2_group_key, _p2_secret_key) = p2_state.finish()?;
@@ -2016,11 +2005,11 @@ mod test {
             let rng = OsRng;
 
             let (p1, p1coeffs, dh_sk1) =
-                Participant::<Secp256k1Sha256>::new_dealer(&params, 1, rng).unwrap();
+                Participant::<Secp256k1Sha256>::new_dealer(params, 1, rng).unwrap();
             let (p2, p2coeffs, dh_sk2) =
-                Participant::<Secp256k1Sha256>::new_dealer(&params, 2, rng).unwrap();
+                Participant::<Secp256k1Sha256>::new_dealer(params, 2, rng).unwrap();
             let (p3, p3coeffs, dh_sk3) =
-                Participant::<Secp256k1Sha256>::new_dealer(&params, 3, rng).unwrap();
+                Participant::<Secp256k1Sha256>::new_dealer(params, 3, rng).unwrap();
 
             p1.proof_of_secret_key
                 .as_ref()
@@ -2039,9 +2028,9 @@ mod test {
                 vec![p1.clone(), p2.clone(), p3.clone()];
             let (p1_state, _participant_lists) =
                 DistributedKeyGeneration::<RoundOne, Secp256k1Sha256>::bootstrap(
-                    &params,
+                    params,
                     &dh_sk1,
-                    &p1.index,
+                    p1.index,
                     &p1coeffs,
                     &participants,
                     rng,
@@ -2050,9 +2039,9 @@ mod test {
 
             let (p2_state, _participant_lists) =
                 DistributedKeyGeneration::<RoundOne, Secp256k1Sha256>::bootstrap(
-                    &params,
+                    params,
                     &dh_sk2,
-                    &p2.index,
+                    p2.index,
                     &p2coeffs,
                     &participants,
                     rng,
@@ -2061,9 +2050,9 @@ mod test {
 
             let (p3_state, _participant_lists) =
                 DistributedKeyGeneration::<RoundOne, Secp256k1Sha256>::bootstrap(
-                    &params,
+                    params,
                     &dh_sk3,
-                    &p3.index,
+                    p3.index,
                     &p3coeffs,
                     &participants,
                     rng,
@@ -2095,14 +2084,14 @@ mod test {
 
                 let p1_state = p1_state
                     .clone()
-                    .to_round_two(p1_my_encrypted_secret_shares, rng)?;
+                    .to_round_two(&p1_my_encrypted_secret_shares, rng)?;
                 let p3_state = p3_state
                     .clone()
-                    .to_round_two(p3_my_encrypted_secret_shares, rng)?;
+                    .to_round_two(&p3_my_encrypted_secret_shares, rng)?;
 
                 let complaints = p2_state
                     .clone()
-                    .to_round_two(p2_my_encrypted_secret_shares, rng);
+                    .to_round_two(&p2_my_encrypted_secret_shares, rng);
                 assert!(complaints.is_err());
                 let complaints = complaints.unwrap_err();
                 if let Error::Complaint(complaints) = complaints {
@@ -2147,14 +2136,14 @@ mod test {
 
                 let p1_state = p1_state
                     .clone()
-                    .to_round_two(p1_my_encrypted_secret_shares, rng)?;
+                    .to_round_two(&p1_my_encrypted_secret_shares, rng)?;
                 let p3_state = p3_state
                     .clone()
-                    .to_round_two(p3_my_encrypted_secret_shares, rng)?;
+                    .to_round_two(&p3_my_encrypted_secret_shares, rng)?;
 
                 let complaints = p2_state
                     .clone()
-                    .to_round_two(p2_my_encrypted_secret_shares, rng);
+                    .to_round_two(&p2_my_encrypted_secret_shares, rng);
                 assert!(complaints.is_err());
                 let complaints = complaints.unwrap_err();
                 if let Error::Complaint(complaints) = complaints {
@@ -2206,14 +2195,14 @@ mod test {
 
                 let p1_state = p1_state
                     .clone()
-                    .to_round_two(p1_my_encrypted_secret_shares, rng)?;
+                    .to_round_two(&p1_my_encrypted_secret_shares, rng)?;
                 let p3_state = p3_state
                     .clone()
-                    .to_round_two(p3_my_encrypted_secret_shares, rng)?;
+                    .to_round_two(&p3_my_encrypted_secret_shares, rng)?;
 
                 let complaints = p2_state
                     .clone()
-                    .to_round_two(p2_my_encrypted_secret_shares, rng);
+                    .to_round_two(&p2_my_encrypted_secret_shares, rng);
                 assert!(complaints.is_err());
                 let complaints = complaints.unwrap_err();
                 if let Error::Complaint(complaints) = complaints {
@@ -2251,7 +2240,7 @@ mod test {
 
                 let p3_state = p3_state
                     .clone()
-                    .to_round_two(p3_my_encrypted_secret_shares, rng)?;
+                    .to_round_two(&p3_my_encrypted_secret_shares, rng)?;
 
                 let bad_index = p3_state.blame(&p1_their_encrypted_secret_shares[0], &complaint);
                 assert!(bad_index == 2);
@@ -2268,9 +2257,9 @@ mod test {
             let params = ThresholdParameters::new(3, 2);
             let rng = OsRng;
 
-            let (p1, p1coeffs, p1_dh_sk) = Participant::new_dealer(&params, 1, rng).unwrap();
-            let (p2, p2coeffs, p2_dh_sk) = Participant::new_dealer(&params, 2, rng).unwrap();
-            let (p3, p3coeffs, p3_dh_sk) = Participant::new_dealer(&params, 3, rng).unwrap();
+            let (p1, p1coeffs, p1_dh_sk) = Participant::new_dealer(params, 1, rng).unwrap();
+            let (p2, p2coeffs, p2_dh_sk) = Participant::new_dealer(params, 2, rng).unwrap();
+            let (p3, p3coeffs, p3_dh_sk) = Participant::new_dealer(params, 3, rng).unwrap();
 
             p1.proof_of_secret_key
                 .as_ref()
@@ -2289,9 +2278,9 @@ mod test {
                 vec![p1.clone(), p2.clone(), p3.clone()];
             let (p1_state, _participant_lists) =
                 DistributedKeyGeneration::<RoundOne, Secp256k1Sha256>::bootstrap(
-                    &params,
+                    params,
                     &p1_dh_sk,
-                    &p1.index,
+                    p1.index,
                     &p1coeffs,
                     &participants,
                     rng,
@@ -2300,9 +2289,9 @@ mod test {
 
             let (p2_state, _participant_lists) =
                 DistributedKeyGeneration::<RoundOne, Secp256k1Sha256>::bootstrap(
-                    &params,
+                    params,
                     &p2_dh_sk,
-                    &p2.index,
+                    p2.index,
                     &p2coeffs,
                     &participants,
                     rng,
@@ -2311,9 +2300,9 @@ mod test {
 
             let (p3_state, _participant_lists) =
                 DistributedKeyGeneration::<RoundOne, Secp256k1Sha256>::bootstrap(
-                    &params,
+                    params,
                     &p3_dh_sk,
-                    &p3.index,
+                    p3.index,
                     &p3coeffs,
                     &participants,
                     rng,
@@ -2375,13 +2364,13 @@ mod test {
 
                 let p1_state = p1_state
                     .clone()
-                    .to_round_two(p1_my_encrypted_secret_shares, rng)?;
+                    .to_round_two(&p1_my_encrypted_secret_shares, rng)?;
                 let p2_state = p2_state
                     .clone()
-                    .to_round_two(p2_my_encrypted_secret_shares, rng)?;
+                    .to_round_two(&p2_my_encrypted_secret_shares, rng)?;
                 let p3_state = p3_state
                     .clone()
-                    .to_round_two(p3_my_encrypted_secret_shares, rng)?;
+                    .to_round_two(&p3_my_encrypted_secret_shares, rng)?;
 
                 let (p1_group_key, _p1_secret_key) = p1_state.clone().finish()?;
                 let (p2_group_key, _p2_secret_key) = p2_state.finish()?;
@@ -2422,10 +2411,10 @@ mod test {
                     p3_their_encrypted_secret_shares[2].clone(),
                 ];
 
-                let p1_state = p1_state.to_round_two(p1_my_encrypted_secret_shares, rng)?;
-                let p3_state = p3_state.to_round_two(p3_my_encrypted_secret_shares, rng)?;
+                let p1_state = p1_state.to_round_two(&p1_my_encrypted_secret_shares, rng)?;
+                let p3_state = p3_state.to_round_two(&p3_my_encrypted_secret_shares, rng)?;
 
-                let complaints = p2_state.to_round_two(p2_my_encrypted_secret_shares, rng);
+                let complaints = p2_state.to_round_two(&p2_my_encrypted_secret_shares, rng);
                 assert!(complaints.is_err());
                 let complaints = complaints.unwrap_err();
                 if let Error::Complaint(complaints) = complaints {
@@ -2467,11 +2456,11 @@ mod test {
             let rng = OsRng;
 
             let (p1, p1coeffs, p1_dh_sk) =
-                Participant::<Secp256k1Sha256>::new_dealer(&params, 1, rng).unwrap();
+                Participant::<Secp256k1Sha256>::new_dealer(params, 1, rng).unwrap();
             let (p2, p2coeffs, p2_dh_sk) =
-                Participant::<Secp256k1Sha256>::new_dealer(&params, 2, rng).unwrap();
+                Participant::<Secp256k1Sha256>::new_dealer(params, 2, rng).unwrap();
             let (p3, p3coeffs, p3_dh_sk) =
-                Participant::<Secp256k1Sha256>::new_dealer(&params, 3, rng).unwrap();
+                Participant::<Secp256k1Sha256>::new_dealer(params, 3, rng).unwrap();
 
             p1.proof_of_secret_key
                 .as_ref()
@@ -2490,9 +2479,9 @@ mod test {
                 vec![p1.clone(), p2.clone(), p3.clone()];
             let (p1_state, _participant_lists) =
                 DistributedKeyGeneration::<RoundOne, Secp256k1Sha256>::bootstrap(
-                    &params,
+                    params,
                     &p1_dh_sk,
-                    &p1.index,
+                    p1.index,
                     &p1coeffs,
                     &participants,
                     rng,
@@ -2501,9 +2490,9 @@ mod test {
 
             let (p2_state, _participant_lists) =
                 DistributedKeyGeneration::<RoundOne, Secp256k1Sha256>::bootstrap(
-                    &params,
+                    params,
                     &p2_dh_sk,
-                    &p2.index,
+                    p2.index,
                     &p2coeffs,
                     &participants,
                     rng,
@@ -2512,9 +2501,9 @@ mod test {
 
             let (p3_state, _participant_lists) =
                 DistributedKeyGeneration::<RoundOne, Secp256k1Sha256>::bootstrap(
-                    &params,
+                    params,
                     &p3_dh_sk,
-                    &p3.index,
+                    p3.index,
                     &p3coeffs,
                     &participants,
                     rng,
@@ -2537,9 +2526,9 @@ mod test {
                 p3_their_encrypted_secret_shares[2].clone(),
             ];
 
-            let p1_state = p1_state.to_round_two(p1_my_encrypted_secret_shares, rng)?;
-            let p2_state = p2_state.to_round_two(p2_my_encrypted_secret_shares, rng)?;
-            let p3_state = p3_state.to_round_two(p3_my_encrypted_secret_shares, rng)?;
+            let p1_state = p1_state.to_round_two(&p1_my_encrypted_secret_shares, rng)?;
+            let p2_state = p2_state.to_round_two(&p2_my_encrypted_secret_shares, rng)?;
+            let p3_state = p3_state.to_round_two(&p3_my_encrypted_secret_shares, rng)?;
 
             let (p1_group_key, p1_secret_key) = p1_state.finish()?;
             let (p2_group_key, p2_secret_key) = p2_state.finish()?;

--- a/src/dkg/nizkpok.rs
+++ b/src/dkg/nizkpok.rs
@@ -55,7 +55,7 @@ impl<C: CipherSuite> NizkPokOfSecretKey<C> {
         m.serialize_compressed(&mut message)
             .map_err(|_| Error::CompressionError)?;
 
-        let s = C::h0(&message)?;
+        let s = C::h0(&message);
         let r = k + (*secret_key * s);
 
         Ok(NizkPokOfSecretKey { s, r })
@@ -80,7 +80,7 @@ impl<C: CipherSuite> NizkPokOfSecretKey<C> {
             .serialize_compressed(&mut message)
             .map_err(|_| Error::CompressionError)?;
 
-        let s_prime = C::h0(&message)?;
+        let s_prime = C::h0(&message);
 
         if self.s == s_prime {
             return Ok(());

--- a/src/dkg/participant.rs
+++ b/src/dkg/participant.rs
@@ -79,7 +79,7 @@ impl<C: CipherSuite> Participant<C> {
     /// Diffie-Hellman private key for secret shares encryption which
     /// must be kept private.
     pub fn new_dealer(
-        parameters: &ThresholdParameters<C>,
+        parameters: ThresholdParameters<C>,
         index: u32,
         mut rng: impl RngCore + CryptoRng,
     ) -> FrostResult<C, (Self, Coefficients<C>, DiffieHellmanPrivateKey<C>)> {
@@ -112,7 +112,7 @@ impl<C: CipherSuite> Participant<C> {
     /// signers's Diffie-Hellman private key for secret shares encryption
     /// which must be kept private.
     pub fn new_signer(
-        parameters: &ThresholdParameters<C>,
+        parameters: ThresholdParameters<C>,
         index: u32,
         mut rng: impl RngCore + CryptoRng,
     ) -> FrostResult<C, (Self, DiffieHellmanPrivateKey<C>)> {
@@ -122,7 +122,7 @@ impl<C: CipherSuite> Participant<C> {
     }
 
     fn new_internal(
-        parameters: &ThresholdParameters<C>,
+        parameters: ThresholdParameters<C>,
         is_signer: bool,
         index: u32,
         secret_key: Option<Scalar<C>>,
@@ -236,8 +236,8 @@ impl<C: CipherSuite> Participant<C> {
     /// It also returns a list of the valid / misbehaving participants
     /// of the new set for handling outside of this crate.
     pub fn reshare(
-        parameters: &ThresholdParameters<C>,
-        secret_key: IndividualSigningKey<C>,
+        parameters: ThresholdParameters<C>,
+        secret_key: &IndividualSigningKey<C>,
         signers: &[Participant<C>],
         mut rng: impl RngCore + CryptoRng,
     ) -> FrostResult<C, (Self, Vec<EncryptedSecretShare<C>>, DKGParticipantList<C>)> {
@@ -255,7 +255,7 @@ impl<C: CipherSuite> Participant<C> {
         let (participant_state, participant_lists) = DistributedKeyGeneration::new_state_internal(
             parameters,
             &dh_private_key,
-            &secret_key.index,
+            secret_key.index,
             Some(&coefficients),
             signers,
             true,
@@ -311,7 +311,7 @@ mod test {
         let params = ThresholdParameters::new(3, 2);
         let rng = OsRng;
 
-        let result = Participant::<Secp256k1Sha256>::new_dealer(&params, 0, rng);
+        let result = Participant::<Secp256k1Sha256>::new_dealer(params, 0, rng);
         assert!(result.is_err());
         assert_eq!(result.unwrap_err(), Error::IndexIsZero);
     }

--- a/src/dkg/secret_share.rs
+++ b/src/dkg/secret_share.rs
@@ -63,11 +63,11 @@ impl<C: CipherSuite> Drop for SecretShare<C> {
 impl<C: CipherSuite> SecretShare<C> {
     /// Evaluate the polynomial, `f(x)` for the secret coefficients at the value of `x` .
     pub(crate) fn evaluate_polynomial(
-        sender_index: &u32,
-        receiver_index: &u32,
+        sender_index: u32,
+        receiver_index: u32,
         coefficients: &Coefficients<C>,
     ) -> SecretShare<C> {
-        let term: Scalar<C> = (*receiver_index).into();
+        let term: Scalar<C> = (receiver_index).into();
         let mut sum = Scalar::<C>::ZERO;
 
         // Evaluate using Horner's method.
@@ -80,8 +80,8 @@ impl<C: CipherSuite> SecretShare<C> {
             }
         }
         SecretShare {
-            sender_index: *sender_index,
-            receiver_index: *receiver_index,
+            sender_index,
+            receiver_index,
             polynomial_evaluation: sum,
         }
     }
@@ -104,9 +104,10 @@ impl<C: CipherSuite> SecretShare<C> {
             }
         }
 
-        match lhs.into_affine() == rhs.into_affine() {
-            true => Ok(()),
-            false => Err(Error::ShareVerificationError),
+        if lhs.into_affine() == rhs.into_affine() {
+            Ok(())
+        } else {
+            Err(Error::ShareVerificationError)
         }
     }
 }
@@ -136,6 +137,7 @@ impl<C: CipherSuite> Drop for EncryptedSecretShare<C> {
 
 impl<C: CipherSuite> EncryptedSecretShare<C> {
     /// Constructs a new [`EncryptedSecretShare`] from the provided inputs.
+    #[must_use]
     pub fn new(
         sender_index: u32,
         receiver_index: u32,

--- a/src/keys.rs
+++ b/src/keys.rs
@@ -18,7 +18,7 @@ use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
 
 use zeroize::Zeroize;
 
-/// A Diffie-Hellman private key wrapper type around a PrimeField.
+/// A Diffie-Hellman private key wrapper type around a `PrimeField`.
 #[derive(Clone, Debug, Eq, PartialEq, CanonicalSerialize, CanonicalDeserialize, Zeroize)]
 pub struct DiffieHellmanPrivateKey<C: CipherSuite>(pub(crate) <C::G as Group>::ScalarField);
 
@@ -30,7 +30,7 @@ impl<C: CipherSuite> Drop for DiffieHellmanPrivateKey<C> {
     }
 }
 
-/// A Diffie-Hellman public key wrapper type around a CurveGroup.
+/// A Diffie-Hellman public key wrapper type around a `CurveGroup`.
 #[derive(Clone, Debug, Eq, PartialEq, CanonicalSerialize, CanonicalDeserialize)]
 pub struct DiffieHellmanPublicKey<C: CipherSuite> {
     pub(crate) key: C::G,
@@ -99,11 +99,11 @@ impl<C: CipherSuite> IndividualVerifyingKey<C> {
         let term: <C::G as Group>::ScalarField = self.index.into();
 
         let mut index_vector = Vec::with_capacity(commitments.len());
-        for commitment in commitments.iter() {
+        for commitment in commitments {
             index_vector.push(commitment.index);
         }
 
-        for commitment in commitments.iter() {
+        for commitment in commitments {
             let mut tmp: C::G = <C as CipherSuite>::G::zero();
             for (index, com) in commitment.points.iter().rev().enumerate() {
                 tmp += com;
@@ -122,9 +122,10 @@ impl<C: CipherSuite> IndividualVerifyingKey<C> {
             rhs += tmp.mul(coeff);
         }
 
-        match self.share.into_affine() == rhs.into_affine() {
-            true => Ok(()),
-            false => Err(Error::ShareVerificationError),
+        if self.share.into_affine() == rhs.into_affine() {
+            Ok(())
+        } else {
+            Err(Error::ShareVerificationError)
         }
     }
 
@@ -147,6 +148,7 @@ impl<C: CipherSuite> IndividualVerifyingKey<C> {
     /// # Returns
     ///
     /// An [`IndividualVerifyingKey`] .
+    #[must_use]
     pub fn generate_from_commitments(
         participant_index: u32,
         commitments: &[VerifiableSecretSharingCommitment<C>],
@@ -155,11 +157,11 @@ impl<C: CipherSuite> IndividualVerifyingKey<C> {
         let term: <C::G as Group>::ScalarField = participant_index.into();
 
         let mut index_vector = Vec::with_capacity(commitments.len());
-        for commitment in commitments.iter() {
+        for commitment in commitments {
             index_vector.push(commitment.index);
         }
 
-        for commitment in commitments.iter() {
+        for commitment in commitments {
             let mut tmp: C::G = <C as CipherSuite>::G::zero();
             for (index, com) in commitment.points.iter().rev().enumerate() {
                 tmp += com;
@@ -249,9 +251,10 @@ impl<C: CipherSuite> GroupVerifyingKey<C> {
         )
         .map_err(|_| Error::InvalidSignature)?;
 
-        match signature.group_commitment == retrieved_commitment {
-            true => Ok(()),
-            false => Err(Error::InvalidSignature),
+        if signature.group_commitment == retrieved_commitment {
+            Ok(())
+        } else {
+            Err(Error::InvalidSignature)
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,9 +15,9 @@
 //! signature.
 //!
 //! For this, they need to define a [`CipherSuite`] to be used in the DKG and signing sessions.
-//! This CipherSuite is used to parameterize ICE-FROST over an arbitrary curve backend, with
+//! This [`CipherSuite`] is used to parameterize ICE-FROST over an arbitrary curve backend, with
 //! an arbitrary underlying hasher instantiating all random oracles.
-//! The following example creates an ICE-FROST CipherSuite over the Secp256k1 curve,
+//! The following example creates an ICE-FROST [`CipherSuite`] over the Secp256k1 curve,
 //! with SHA-256 as internal hash function.
 //!
 //! ```rust
@@ -42,7 +42,7 @@
 //! }
 //! ```
 //!
-//! We will use the `Secp256k1Sha256` as CipherSuite for all the following examples.
+//! We will use the `Secp256k1Sha256` as [`CipherSuite`] for all the following examples.
 //!
 //! Following the [`CipherSuite`] definition, Alice, Bob, and Carol need to define their
 //! ICE-FROST session parameters as follows.
@@ -78,9 +78,9 @@
 //! #
 //! // All ICE-FROST methods requiring a source of entropy should use a cryptographic pseudorandom
 //! // generator to prevent any risk of private information retrieval.
-//! let (alice, alice_coefficients, alice_dh_sk) = Participant::new_dealer(&params, 1, &mut rng)?;
-//! let (bob, bob_coefficients, bob_dh_sk) = Participant::new_dealer(&params, 2, &mut rng)?;
-//! let (carol, carol_coefficients, carol_dh_sk) = Participant::new_dealer(&params, 3, &mut rng)?;
+//! let (alice, alice_coefficients, alice_dh_sk) = Participant::new_dealer(params, 1, &mut rng)?;
+//! let (bob, bob_coefficients, bob_dh_sk) = Participant::new_dealer(params, 2, &mut rng)?;
+//! let (carol, carol_coefficients, carol_dh_sk) = Participant::new_dealer(params, 3, &mut rng)?;
 //! # Ok(()) } fn main() { assert!(do_test().is_ok()); }
 //! ```
 //!
@@ -107,17 +107,17 @@
 //! # let params = ThresholdParameters::new(3,2);
 //! # let mut rng = OsRng;
 //! #
-//! # let (alice, alice_coefficients, alice_dh_sk) = Participant::new_dealer(&params, 1, &mut rng)?;
-//! # let (bob, bob_coefficients, bob_dh_sk) = Participant::new_dealer(&params, 2, &mut rng)?;
-//! # let (carol, carol_coefficients, carol_dh_sk) = Participant::new_dealer(&params, 3, &mut rng)?;
+//! # let (alice, alice_coefficients, alice_dh_sk) = Participant::new_dealer(params, 1, &mut rng)?;
+//! # let (bob, bob_coefficients, bob_dh_sk) = Participant::new_dealer(params, 2, &mut rng)?;
+//! # let (carol, carol_coefficients, carol_dh_sk) = Participant::new_dealer(params, 3, &mut rng)?;
 //!
 //! let participants: Vec<Participant<Secp256k1Sha256>> =
 //!     vec![alice.clone(), bob.clone(), carol.clone()];
 //! let (alice_state, participant_lists) =
 //!     DistributedKeyGeneration::<_, Secp256k1Sha256>::bootstrap(
-//!         &params,
+//!         params,
 //!         &alice_dh_sk,
-//!         &alice.index,
+//!         alice.index,
 //!         &alice_coefficients,
 //!         &participants,
 //!         &mut rng,
@@ -143,12 +143,12 @@
 //! # let params = ThresholdParameters::new(3,2);
 //! # let mut rng = OsRng;
 //! #
-//! # let (alice, alice_coefficients, alice_dh_sk) = Participant::new_dealer(&params, 1, &mut rng)?;
-//! # let (bob, bob_coefficients, bob_dh_sk) = Participant::new_dealer(&params, 2, &mut rng)?;
-//! # let (carol, carol_coefficients, carol_dh_sk) = Participant::new_dealer(&params, 3, &mut rng)?;
+//! # let (alice, alice_coefficients, alice_dh_sk) = Participant::new_dealer(params, 1, &mut rng)?;
+//! # let (bob, bob_coefficients, bob_dh_sk) = Participant::new_dealer(params, 2, &mut rng)?;
+//! # let (carol, carol_coefficients, carol_dh_sk) = Participant::new_dealer(params, 3, &mut rng)?;
 //! #
 //! # let participants: Vec<Participant<Secp256k1Sha256>> = vec![alice.clone(), bob.clone(), carol.clone()];
-//! # let (alice_state, participant_lists) = DistributedKeyGeneration::<_, Secp256k1Sha256>::bootstrap(&params, &alice_dh_sk, &alice.index, &alice_coefficients,
+//! # let (alice_state, participant_lists) = DistributedKeyGeneration::<_, Secp256k1Sha256>::bootstrap(params, &alice_dh_sk, alice.index, &alice_coefficients,
 //! #                                                      &participants, &mut rng)?;
 //! let alice_their_encrypted_secret_shares = alice_state.their_encrypted_secret_shares()?;
 //! # Ok(()) } fn main() { assert!(do_test().is_ok()); }
@@ -172,16 +172,16 @@
 //! # let params = ThresholdParameters::new(3,2);
 //! # let mut rng = OsRng;
 //! #
-//! # let (alice, alice_coefficients, alice_dh_sk) = Participant::new_dealer(&params, 1, &mut rng)?;
-//! # let (bob, bob_coefficients, bob_dh_sk) = Participant::new_dealer(&params, 2, &mut rng)?;
-//! # let (carol, carol_coefficients, carol_dh_sk) = Participant::new_dealer(&params, 3, &mut rng)?;
+//! # let (alice, alice_coefficients, alice_dh_sk) = Participant::new_dealer(params, 1, &mut rng)?;
+//! # let (bob, bob_coefficients, bob_dh_sk) = Participant::new_dealer(params, 2, &mut rng)?;
+//! # let (carol, carol_coefficients, carol_dh_sk) = Participant::new_dealer(params, 3, &mut rng)?;
 //! #
 //! # let participants: Vec<Participant<Secp256k1Sha256>> = vec![alice.clone(), bob.clone(), carol.clone()];
 //! let (bob_state, participant_lists) =
 //!     DistributedKeyGeneration::<_, Secp256k1Sha256>::bootstrap(
-//!         &params,
+//!         params,
 //!         &bob_dh_sk,
-//!         &bob.index,
+//!         bob.index,
 //!         &bob_coefficients,
 //!         &participants,
 //!         &mut rng,
@@ -191,12 +191,12 @@
 //! # let params = ThresholdParameters::new(3,2);
 //! # let mut rng = OsRng;
 //! #
-//! # let (alice, alice_coefficients, alice_dh_sk) = Participant::new_dealer(&params, 1, &mut rng)?;
-//! # let (bob, bob_coefficients, bob_dh_sk) = Participant::new_dealer(&params, 2, &mut rng)?;
-//! # let (carol, carol_coefficients, carol_dh_sk) = Participant::new_dealer(&params, 3, &mut rng)?;
+//! # let (alice, alice_coefficients, alice_dh_sk) = Participant::new_dealer(params, 1, &mut rng)?;
+//! # let (bob, bob_coefficients, bob_dh_sk) = Participant::new_dealer(params, 2, &mut rng)?;
+//! # let (carol, carol_coefficients, carol_dh_sk) = Participant::new_dealer(params, 3, &mut rng)?;
 //! #
 //! # let participants: Vec<Participant<Secp256k1Sha256>> = vec![alice.clone(), bob.clone(), carol.clone()];
-//! # let (bob_state, participant_lists) = DistributedKeyGeneration::<_, Secp256k1Sha256>::bootstrap(&params, &bob_dh_sk, &bob.index, &bob_coefficients,
+//! # let (bob_state, participant_lists) = DistributedKeyGeneration::<_, Secp256k1Sha256>::bootstrap(params, &bob_dh_sk, bob.index, &bob_coefficients,
 //! #                                                    &participants, &mut rng)?;
 //!
 //! let bob_their_encrypted_secret_shares = bob_state.their_encrypted_secret_shares()?;
@@ -224,16 +224,16 @@
 //! # let params = ThresholdParameters::new(3,2);
 //! # let mut rng = OsRng;
 //! #
-//! # let (alice, alice_coefficients, alice_dh_sk) = Participant::new_dealer(&params, 1, &mut rng)?;
-//! # let (bob, bob_coefficients, bob_dh_sk) = Participant::new_dealer(&params, 2, &mut rng)?;
-//! # let (carol, carol_coefficients, carol_dh_sk) = Participant::new_dealer(&params, 3, &mut rng)?;
+//! # let (alice, alice_coefficients, alice_dh_sk) = Participant::new_dealer(params, 1, &mut rng)?;
+//! # let (bob, bob_coefficients, bob_dh_sk) = Participant::new_dealer(params, 2, &mut rng)?;
+//! # let (carol, carol_coefficients, carol_dh_sk) = Participant::new_dealer(params, 3, &mut rng)?;
 //! #
 //! # let participants: Vec<Participant<Secp256k1Sha256>> = vec![alice.clone(), bob.clone(), carol.clone()];
 //! let (carol_state, participant_lists) =
 //!     DistributedKeyGeneration::<_, Secp256k1Sha256>::bootstrap(
-//!         &params,
+//!         params,
 //!         &carol_dh_sk,
-//!         &carol.index,
+//!         carol.index,
 //!         &carol_coefficients,
 //!         &participants,
 //!         &mut rng,
@@ -243,12 +243,12 @@
 //! # let params = ThresholdParameters::new(3,2);
 //! # let mut rng = OsRng;
 //! #
-//! # let (alice, alice_coefficients, alice_dh_sk) = Participant::new_dealer(&params, 1, &mut rng)?;
-//! # let (bob, bob_coefficients, bob_dh_sk) = Participant::new_dealer(&params, 2, &mut rng)?;
-//! # let (carol, carol_coefficients, carol_dh_sk) = Participant::new_dealer(&params, 3, &mut rng)?;
+//! # let (alice, alice_coefficients, alice_dh_sk) = Participant::new_dealer(params, 1, &mut rng)?;
+//! # let (bob, bob_coefficients, bob_dh_sk) = Participant::new_dealer(params, 2, &mut rng)?;
+//! # let (carol, carol_coefficients, carol_dh_sk) = Participant::new_dealer(params, 3, &mut rng)?;
 //! #
 //! # let participants: Vec<Participant<Secp256k1Sha256>> = vec![alice.clone(), bob.clone(), carol.clone()];
-//! # let (carol_state, participant_lists) = DistributedKeyGeneration::<_, Secp256k1Sha256>::bootstrap(&params, &carol_dh_sk, &carol.index, &carol_coefficients,
+//! # let (carol_state, participant_lists) = DistributedKeyGeneration::<_, Secp256k1Sha256>::bootstrap(params, &carol_dh_sk, carol.index, &carol_coefficients,
 //! #                                                      &participants, &mut rng)?;
 //!
 //! let carol_their_encrypted_secret_shares = carol_state.their_encrypted_secret_shares()?;
@@ -276,20 +276,20 @@
 //! # let params = ThresholdParameters::new(3,2);
 //! # let mut rng = OsRng;
 //! #
-//! # let (alice, alice_coefficients, alice_dh_sk) = Participant::new_dealer(&params, 1, &mut rng)?;
-//! # let (bob, bob_coefficients, bob_dh_sk) = Participant::new_dealer(&params, 2, &mut rng)?;
-//! # let (carol, carol_coefficients, carol_dh_sk) = Participant::new_dealer(&params, 3, &mut rng)?;
+//! # let (alice, alice_coefficients, alice_dh_sk) = Participant::new_dealer(params, 1, &mut rng)?;
+//! # let (bob, bob_coefficients, bob_dh_sk) = Participant::new_dealer(params, 2, &mut rng)?;
+//! # let (carol, carol_coefficients, carol_dh_sk) = Participant::new_dealer(params, 3, &mut rng)?;
 //! #
 //! # let participants: Vec<Participant<Secp256k1Sha256>> = vec![alice.clone(), bob.clone(), carol.clone()];
-//! # let (alice_state, participant_lists) = DistributedKeyGeneration::<_, Secp256k1Sha256>::bootstrap(&params, &alice_dh_sk, &alice.index, &alice_coefficients,
+//! # let (alice_state, participant_lists) = DistributedKeyGeneration::<_, Secp256k1Sha256>::bootstrap(params, &alice_dh_sk, alice.index, &alice_coefficients,
 //! #                                                      &participants, &mut rng)?;
 //! # let alice_their_encrypted_secret_shares = alice_state.their_encrypted_secret_shares()?;
 //! #
-//! # let (bob_state, participant_lists) = DistributedKeyGeneration::<_, Secp256k1Sha256>::bootstrap(&params, &bob_dh_sk, &bob.index, &bob_coefficients,
+//! # let (bob_state, participant_lists) = DistributedKeyGeneration::<_, Secp256k1Sha256>::bootstrap(params, &bob_dh_sk, bob.index, &bob_coefficients,
 //! #                                                    &participants, &mut rng)?;
 //! # let bob_their_encrypted_secret_shares = bob_state.their_encrypted_secret_shares()?;
 //! #
-//! # let (carol_state, participant_lists) = DistributedKeyGeneration::<_, Secp256k1Sha256>::bootstrap(&params, &carol_dh_sk, &carol.index, &carol_coefficients,
+//! # let (carol_state, participant_lists) = DistributedKeyGeneration::<_, Secp256k1Sha256>::bootstrap(params, &carol_dh_sk, carol.index, &carol_coefficients,
 //! #                                                      &participants, &mut rng)?;
 //! # let carol_their_encrypted_secret_shares = carol_state.their_encrypted_secret_shares()?;
 //! let alice_my_encrypted_secret_shares = vec![
@@ -329,20 +329,20 @@
 //! # let params = ThresholdParameters::new(3,2);
 //! # let mut rng = OsRng;
 //! #
-//! # let (alice, alice_coefficients, alice_dh_sk) = Participant::new_dealer(&params, 1, &mut rng)?;
-//! # let (bob, bob_coefficients, bob_dh_sk) = Participant::new_dealer(&params, 2, &mut rng)?;
-//! # let (carol, carol_coefficients, carol_dh_sk) = Participant::new_dealer(&params, 3, &mut rng)?;
+//! # let (alice, alice_coefficients, alice_dh_sk) = Participant::new_dealer(params, 1, &mut rng)?;
+//! # let (bob, bob_coefficients, bob_dh_sk) = Participant::new_dealer(params, 2, &mut rng)?;
+//! # let (carol, carol_coefficients, carol_dh_sk) = Participant::new_dealer(params, 3, &mut rng)?;
 //! #
 //! # let participants: Vec<Participant<Secp256k1Sha256>> = vec![alice.clone(), bob.clone(), carol.clone()];
-//! # let (alice_state, participant_lists) = DistributedKeyGeneration::<_, Secp256k1Sha256>::bootstrap(&params, &alice_dh_sk, &alice.index, &alice_coefficients,
+//! # let (alice_state, participant_lists) = DistributedKeyGeneration::<_, Secp256k1Sha256>::bootstrap(params, &alice_dh_sk, alice.index, &alice_coefficients,
 //! #                                                      &participants, &mut rng)?;
 //! # let alice_their_encrypted_secret_shares = alice_state.their_encrypted_secret_shares()?;
 //! #
-//! # let (bob_state, participant_lists) = DistributedKeyGeneration::<_, Secp256k1Sha256>::bootstrap(&params, &bob_dh_sk, &bob.index, &bob_coefficients,
+//! # let (bob_state, participant_lists) = DistributedKeyGeneration::<_, Secp256k1Sha256>::bootstrap(params, &bob_dh_sk, bob.index, &bob_coefficients,
 //! #                                                    &participants, &mut rng)?;
 //! # let bob_their_encrypted_secret_shares = bob_state.their_encrypted_secret_shares()?;
 //! #
-//! # let (carol_state, participant_lists) = DistributedKeyGeneration::<_, Secp256k1Sha256>::bootstrap(&params, &carol_dh_sk, &carol.index, &carol_coefficients,
+//! # let (carol_state, participant_lists) = DistributedKeyGeneration::<_, Secp256k1Sha256>::bootstrap(params, &carol_dh_sk, carol.index, &carol_coefficients,
 //! #                                                      &participants, &mut rng)?;
 //! # let carol_their_encrypted_secret_shares = carol_state.their_encrypted_secret_shares()?;
 //! # let alice_my_encrypted_secret_shares = vec![alice_their_encrypted_secret_shares[0].clone(),
@@ -355,9 +355,9 @@
 //! #                                   bob_their_encrypted_secret_shares[2].clone(),
 //! #                                   carol_their_encrypted_secret_shares[2].clone()];
 //! #
-//! let alice_state = alice_state.to_round_two(alice_my_encrypted_secret_shares, &mut rng)?;
-//! let bob_state = bob_state.to_round_two(bob_my_encrypted_secret_shares, &mut rng)?;
-//! let carol_state = carol_state.to_round_two(carol_my_encrypted_secret_shares, &mut rng)?;
+//! let alice_state = alice_state.to_round_two(&alice_my_encrypted_secret_shares, &mut rng)?;
+//! let bob_state = bob_state.to_round_two(&bob_my_encrypted_secret_shares, &mut rng)?;
+//! let carol_state = carol_state.to_round_two(&carol_my_encrypted_secret_shares, &mut rng)?;
 //! # Ok(()) } fn main() { assert!(do_test().is_ok()); }
 //! ```
 //!
@@ -382,20 +382,20 @@
 //! # let params = ThresholdParameters::new(3,2);
 //! # let mut rng = OsRng;
 //! #
-//! # let (alice, alice_coefficients, alice_dh_sk) = Participant::new_dealer(&params, 1, &mut rng)?;
-//! # let (bob, bob_coefficients, bob_dh_sk) = Participant::new_dealer(&params, 2, &mut rng)?;
-//! # let (carol, carol_coefficients, carol_dh_sk) = Participant::new_dealer(&params, 3, &mut rng)?;
+//! # let (alice, alice_coefficients, alice_dh_sk) = Participant::new_dealer(params, 1, &mut rng)?;
+//! # let (bob, bob_coefficients, bob_dh_sk) = Participant::new_dealer(params, 2, &mut rng)?;
+//! # let (carol, carol_coefficients, carol_dh_sk) = Participant::new_dealer(params, 3, &mut rng)?;
 //! #
 //! # let participants: Vec<Participant<Secp256k1Sha256>> = vec![alice.clone(), bob.clone(), carol.clone()];
-//! # let (alice_state, participant_lists) = DistributedKeyGeneration::<_, Secp256k1Sha256>::bootstrap(&params, &alice_dh_sk, &alice.index, &alice_coefficients,
+//! # let (alice_state, participant_lists) = DistributedKeyGeneration::<_, Secp256k1Sha256>::bootstrap(params, &alice_dh_sk, alice.index, &alice_coefficients,
 //! #                                                      &participants, &mut rng)?;
 //! # let alice_their_encrypted_secret_shares = alice_state.their_encrypted_secret_shares()?;
 //! #
-//! # let (bob_state, participant_lists) = DistributedKeyGeneration::<_, Secp256k1Sha256>::bootstrap(&params, &bob_dh_sk, &bob.index, &bob_coefficients,
+//! # let (bob_state, participant_lists) = DistributedKeyGeneration::<_, Secp256k1Sha256>::bootstrap(params, &bob_dh_sk, bob.index, &bob_coefficients,
 //! #                                                    &participants, &mut rng)?;
 //! # let bob_their_encrypted_secret_shares = bob_state.their_encrypted_secret_shares()?;
 //! #
-//! # let (carol_state, participant_lists) = DistributedKeyGeneration::<_, Secp256k1Sha256>::bootstrap(&params, &carol_dh_sk, &carol.index, &carol_coefficients,
+//! # let (carol_state, participant_lists) = DistributedKeyGeneration::<_, Secp256k1Sha256>::bootstrap(params, &carol_dh_sk, carol.index, &carol_coefficients,
 //! #                                                      &participants, &mut rng)?;
 //! # let carol_their_encrypted_secret_shares = carol_state.their_encrypted_secret_shares()?;
 //! # let alice_my_encrypted_secret_shares = vec![alice_their_encrypted_secret_shares[0].clone(),
@@ -408,9 +408,9 @@
 //! #                                   bob_their_encrypted_secret_shares[2].clone(),
 //! #                                   carol_their_encrypted_secret_shares[2].clone()];
 //! #
-//! # let alice_state = alice_state.to_round_two(alice_my_encrypted_secret_shares, &mut rng)?;
-//! # let bob_state = bob_state.to_round_two(bob_my_encrypted_secret_shares, &mut rng)?;
-//! # let carol_state = carol_state.to_round_two(carol_my_encrypted_secret_shares, &mut rng)?;
+//! # let alice_state = alice_state.to_round_two(&alice_my_encrypted_secret_shares, &mut rng)?;
+//! # let bob_state = bob_state.to_round_two(&bob_my_encrypted_secret_shares, &mut rng)?;
+//! # let carol_state = carol_state.to_round_two(&carol_my_encrypted_secret_shares, &mut rng)?;
 //! #
 //! let (alice_group_key, alice_secret_key) = alice_state.finish()?;
 //! let (bob_group_key, bob_secret_key) = bob_state.finish()?;
@@ -448,22 +448,22 @@
 //! # let params = ThresholdParameters::new(3,2);
 //! # let mut rng = OsRng;
 //! #
-//! # let (alice, alice_coefficients, alice_dh_sk) = Participant::new_dealer(&params, 1, &mut rng)?;
-//! # let (bob, bob_coefficients, bob_dh_sk) = Participant::new_dealer(&params, 2, &mut rng)?;
-//! # let (carol, carol_coefficients, carol_dh_sk) = Participant::new_dealer(&params, 3, &mut rng)?;
+//! # let (alice, alice_coefficients, alice_dh_sk) = Participant::new_dealer(params, 1, &mut rng)?;
+//! # let (bob, bob_coefficients, bob_dh_sk) = Participant::new_dealer(params, 2, &mut rng)?;
+//! # let (carol, carol_coefficients, carol_dh_sk) = Participant::new_dealer(params, 3, &mut rng)?;
 //!
 //! // Perform regular 2-out-of-3 DKG...
 //! #
 //! # let participants: Vec<Participant<Secp256k1Sha256>> = vec![alice.clone(), bob.clone(), carol.clone()];
-//! # let (alice_state, participant_lists) = DistributedKeyGeneration::<_, Secp256k1Sha256>::bootstrap(&params, &alice_dh_sk, &alice.index, &alice_coefficients,
+//! # let (alice_state, participant_lists) = DistributedKeyGeneration::<_, Secp256k1Sha256>::bootstrap(params, &alice_dh_sk, alice.index, &alice_coefficients,
 //! #                                                      &participants, &mut rng)?;
 //! # let alice_their_encrypted_secret_shares = alice_state.their_encrypted_secret_shares()?;
 //! #
-//! # let (bob_state, participant_lists) = DistributedKeyGeneration::<_, Secp256k1Sha256>::bootstrap(&params, &bob_dh_sk, &bob.index, &bob_coefficients,
+//! # let (bob_state, participant_lists) = DistributedKeyGeneration::<_, Secp256k1Sha256>::bootstrap(params, &bob_dh_sk, bob.index, &bob_coefficients,
 //! #                                                    &participants, &mut rng)?;
 //! # let bob_their_encrypted_secret_shares = bob_state.their_encrypted_secret_shares()?;
 //! #
-//! # let (carol_state, participant_lists) = DistributedKeyGeneration::<_, Secp256k1Sha256>::bootstrap(&params, &carol_dh_sk, &carol.index, &carol_coefficients,
+//! # let (carol_state, participant_lists) = DistributedKeyGeneration::<_, Secp256k1Sha256>::bootstrap(params, &carol_dh_sk, carol.index, &carol_coefficients,
 //! #                                                      &participants, &mut rng)?;
 //! # let carol_their_encrypted_secret_shares = carol_state.their_encrypted_secret_shares()?;
 //! # let alice_my_encrypted_secret_shares = vec![alice_their_encrypted_secret_shares[0].clone(),
@@ -476,9 +476,9 @@
 //! #                                   bob_their_encrypted_secret_shares[2].clone(),
 //! #                                   carol_their_encrypted_secret_shares[2].clone()];
 //! #
-//! # let alice_state = alice_state.to_round_two(alice_my_encrypted_secret_shares, &mut rng)?;
-//! # let bob_state = bob_state.to_round_two(bob_my_encrypted_secret_shares, &mut rng)?;
-//! # let carol_state = carol_state.to_round_two(carol_my_encrypted_secret_shares, &mut rng)?;
+//! # let alice_state = alice_state.to_round_two(&alice_my_encrypted_secret_shares, &mut rng)?;
+//! # let bob_state = bob_state.to_round_two(&bob_my_encrypted_secret_shares, &mut rng)?;
+//! # let carol_state = carol_state.to_round_two(&carol_my_encrypted_secret_shares, &mut rng)?;
 //!
 //! let (alice_group_key, alice_secret_key) = alice_state.finish()?;
 //! let (bob_group_key, bob_secret_key) = bob_state.finish()?;
@@ -490,22 +490,22 @@
 //! // Instantiate new configuration parameters and create a new set of signers
 //! let new_params = ThresholdParameters::new(4,3);
 //!
-//! let (alexis, alexis_dh_sk) = Participant::new_signer(&new_params, 1, &mut rng)?;
-//! let (barbara, barbara_dh_sk) = Participant::new_signer(&new_params, 2, &mut rng)?;
-//! let (claire, claire_dh_sk) = Participant::new_signer(&new_params, 3, &mut rng)?;
-//! let (david, david_dh_sk) = Participant::new_signer(&new_params, 4, &mut rng)?;
+//! let (alexis, alexis_dh_sk) = Participant::new_signer(new_params, 1, &mut rng)?;
+//! let (barbara, barbara_dh_sk) = Participant::new_signer(new_params, 2, &mut rng)?;
+//! let (claire, claire_dh_sk) = Participant::new_signer(new_params, 3, &mut rng)?;
+//! let (david, david_dh_sk) = Participant::new_signer(new_params, 4, &mut rng)?;
 //!
 //! let signers: Vec<Participant<Secp256k1Sha256>> =
 //!     vec![alexis.clone(), barbara.clone(), claire.clone(), david.clone()];
 //!
 //! let (alice_as_dealer, alice_encrypted_shares, participant_lists) =
-//!     Participant::reshare(&new_params, alice_secret_key, &signers, &mut rng)?;
+//!     Participant::reshare(new_params, &alice_secret_key, &signers, &mut rng)?;
 //!
 //! let (bob_as_dealer, bob_encrypted_shares, participant_lists) =
-//!     Participant::reshare(&new_params, bob_secret_key, &signers, &mut rng)?;
+//!     Participant::reshare(new_params, &bob_secret_key, &signers, &mut rng)?;
 //!
 //! let (carol_as_dealer, carol_encrypted_shares, participant_lists) =
-//!     Participant::reshare(&new_params, carol_secret_key, &signers, &mut rng)?;
+//!     Participant::reshare(new_params, &carol_secret_key, &signers, &mut rng)?;
 //! # Ok(()) } fn main() { assert!(do_test().is_ok()); }
 //! ```
 //!
@@ -528,20 +528,20 @@
 //! # let params = ThresholdParameters::new(3,2);
 //! # let mut rng = OsRng;
 //! #
-//! # let (alice, alice_coefficients, alice_dh_sk) = Participant::new_dealer(&params, 1, &mut rng)?;
-//! # let (bob, bob_coefficients, bob_dh_sk) = Participant::new_dealer(&params, 2, &mut rng)?;
-//! # let (carol, carol_coefficients, carol_dh_sk) = Participant::new_dealer(&params, 3, &mut rng)?;
+//! # let (alice, alice_coefficients, alice_dh_sk) = Participant::new_dealer(params, 1, &mut rng)?;
+//! # let (bob, bob_coefficients, bob_dh_sk) = Participant::new_dealer(params, 2, &mut rng)?;
+//! # let (carol, carol_coefficients, carol_dh_sk) = Participant::new_dealer(params, 3, &mut rng)?;
 //! #
 //! # let participants: Vec<Participant<Secp256k1Sha256>> = vec![alice.clone(), bob.clone(), carol.clone()];
-//! # let (alice_state, participant_lists) = DistributedKeyGeneration::<_, Secp256k1Sha256>::bootstrap(&params, &alice_dh_sk, &alice.index, &alice_coefficients,
+//! # let (alice_state, participant_lists) = DistributedKeyGeneration::<_, Secp256k1Sha256>::bootstrap(params, &alice_dh_sk, alice.index, &alice_coefficients,
 //! #                                                      &participants, &mut rng)?;
 //! # let alice_their_encrypted_secret_shares = alice_state.their_encrypted_secret_shares()?;
 //! #
-//! # let (bob_state, participant_lists) = DistributedKeyGeneration::<_, Secp256k1Sha256>::bootstrap(&params, &bob_dh_sk, &bob.index, &bob_coefficients,
+//! # let (bob_state, participant_lists) = DistributedKeyGeneration::<_, Secp256k1Sha256>::bootstrap(params, &bob_dh_sk, bob.index, &bob_coefficients,
 //! #                                                    &participants, &mut rng)?;
 //! # let bob_their_encrypted_secret_shares = bob_state.their_encrypted_secret_shares()?;
 //! #
-//! # let (carol_state, participant_lists) = DistributedKeyGeneration::<_, Secp256k1Sha256>::bootstrap(&params, &carol_dh_sk, &carol.index, &carol_coefficients,
+//! # let (carol_state, participant_lists) = DistributedKeyGeneration::<_, Secp256k1Sha256>::bootstrap(params, &carol_dh_sk, carol.index, &carol_coefficients,
 //! #                                                      &participants, &mut rng)?;
 //! # let carol_their_encrypted_secret_shares = carol_state.their_encrypted_secret_shares()?;
 //! # let alice_my_encrypted_secret_shares = vec![alice_their_encrypted_secret_shares[0].clone(),
@@ -554,9 +554,9 @@
 //! #                                   bob_their_encrypted_secret_shares[2].clone(),
 //! #                                   carol_their_encrypted_secret_shares[2].clone()];
 //! #
-//! # let alice_state = alice_state.to_round_two(alice_my_encrypted_secret_shares, &mut rng)?;
-//! # let bob_state = bob_state.to_round_two(bob_my_encrypted_secret_shares, &mut rng)?;
-//! # let carol_state = carol_state.to_round_two(carol_my_encrypted_secret_shares, &mut rng)?;
+//! # let alice_state = alice_state.to_round_two(&alice_my_encrypted_secret_shares, &mut rng)?;
+//! # let bob_state = bob_state.to_round_two(&bob_my_encrypted_secret_shares, &mut rng)?;
+//! # let carol_state = carol_state.to_round_two(&carol_my_encrypted_secret_shares, &mut rng)?;
 //! #
 //! # let (alice_group_key, alice_secret_key) = alice_state.finish()?;
 //! # let (bob_group_key, bob_secret_key) = bob_state.finish()?;
@@ -568,54 +568,54 @@
 //! # // Instantiate new configuration parameters and create a set of signers
 //! # let new_params = ThresholdParameters::new(4,3);
 //! #
-//! # let (alexis, alexis_dh_sk) = Participant::new_signer(&new_params, 1, &mut rng)?;
-//! # let (barbara, barbara_dh_sk) = Participant::new_signer(&new_params, 2, &mut rng)?;
-//! # let (claire, claire_dh_sk) = Participant::new_signer(&new_params, 3, &mut rng)?;
-//! # let (david, david_dh_sk) = Participant::new_signer(&new_params, 4, &mut rng)?;
+//! # let (alexis, alexis_dh_sk) = Participant::new_signer(new_params, 1, &mut rng)?;
+//! # let (barbara, barbara_dh_sk) = Participant::new_signer(new_params, 2, &mut rng)?;
+//! # let (claire, claire_dh_sk) = Participant::new_signer(new_params, 3, &mut rng)?;
+//! # let (david, david_dh_sk) = Participant::new_signer(new_params, 4, &mut rng)?;
 //! #
 //! # let signers: Vec<Participant<Secp256k1Sha256>> = vec![alexis.clone(), barbara.clone(), claire.clone(), david.clone()];
 //! # let (alice_as_dealer, alice_encrypted_shares, participant_lists) =
-//! #     Participant::reshare(&new_params, alice_secret_key, &signers, &mut rng)?;
+//! #     Participant::reshare(new_params, &alice_secret_key, &signers, &mut rng)?;
 //! # let (bob_as_dealer, bob_encrypted_shares, participant_lists) =
-//! #     Participant::reshare(&new_params, bob_secret_key, &signers, &mut rng)?;
+//! #     Participant::reshare(new_params, &bob_secret_key, &signers, &mut rng)?;
 //! # let (carol_as_dealer, carol_encrypted_shares, participant_lists) =
-//! #     Participant::reshare(&new_params, carol_secret_key, &signers, &mut rng)?;
+//! #     Participant::reshare(new_params, &carol_secret_key, &signers, &mut rng)?;
 //! #
 //! let dealers: Vec<Participant<Secp256k1Sha256>> =
 //!     vec![alice_as_dealer.clone(), bob_as_dealer.clone(), carol_as_dealer.clone()];
 //!
 //! let (alexis_state, participant_lists) =
 //!     DistributedKeyGeneration::<_, Secp256k1Sha256>::new(
-//!         &params,
+//!         params,
 //!         &alexis_dh_sk,
-//!         &alexis.index,
+//!         alexis.index,
 //!         &dealers,
 //!         &mut rng,
 //!     )?;
 //!
 //! let (barbara_state, participant_lists) =
 //!     DistributedKeyGeneration::<_, Secp256k1Sha256>::new(
-//!         &params,
+//!         params,
 //!         &barbara_dh_sk,
-//!         &barbara.index,
+//!         barbara.index,
 //!         &dealers,
 //!         &mut rng,
 //!     )?;
 //!
 //! let (claire_state, participant_lists) =
 //!     DistributedKeyGeneration::<_, Secp256k1Sha256>::new(
-//!         &params,
+//!         params,
 //!         &claire_dh_sk,
-//!         &claire.index,
+//!         claire.index,
 //!         &dealers,
 //!         &mut rng,
 //!     )?;
 //!
 //! let (david_state, participant_lists) =
 //!     DistributedKeyGeneration::<_, Secp256k1Sha256>::new(
-//!         &params,
+//!         params,
 //!         &david_dh_sk,
-//!         &david.index,
+//!         david.index,
 //!         &dealers,
 //!         &mut rng,
 //!     )?;
@@ -643,20 +643,20 @@
 //! # let params = ThresholdParameters::new(3,2);
 //! # let mut rng = OsRng;
 //! #
-//! # let (alice, alice_coefficients, alice_dh_sk) = Participant::new_dealer(&params, 1, &mut rng)?;
-//! # let (bob, bob_coefficients, bob_dh_sk) = Participant::new_dealer(&params, 2, &mut rng)?;
-//! # let (carol, carol_coefficients, carol_dh_sk) = Participant::new_dealer(&params, 3, &mut rng)?;
+//! # let (alice, alice_coefficients, alice_dh_sk) = Participant::new_dealer(params, 1, &mut rng)?;
+//! # let (bob, bob_coefficients, bob_dh_sk) = Participant::new_dealer(params, 2, &mut rng)?;
+//! # let (carol, carol_coefficients, carol_dh_sk) = Participant::new_dealer(params, 3, &mut rng)?;
 //! #
 //! # let participants: Vec<Participant<Secp256k1Sha256>> = vec![alice.clone(), bob.clone(), carol.clone()];
-//! # let (alice_state, participant_lists) = DistributedKeyGeneration::<_, Secp256k1Sha256>::bootstrap(&params, &alice_dh_sk, &alice.index, &alice_coefficients,
+//! # let (alice_state, participant_lists) = DistributedKeyGeneration::<_, Secp256k1Sha256>::bootstrap(params, &alice_dh_sk, alice.index, &alice_coefficients,
 //! #                                                      &participants, &mut rng)?;
 //! # let alice_their_encrypted_secret_shares = alice_state.their_encrypted_secret_shares()?;
 //! #
-//! # let (bob_state, participant_lists) = DistributedKeyGeneration::<_, Secp256k1Sha256>::bootstrap(&params, &bob_dh_sk, &bob.index, &bob_coefficients,
+//! # let (bob_state, participant_lists) = DistributedKeyGeneration::<_, Secp256k1Sha256>::bootstrap(params, &bob_dh_sk, bob.index, &bob_coefficients,
 //! #                                                    &participants, &mut rng)?;
 //! # let bob_their_encrypted_secret_shares = bob_state.their_encrypted_secret_shares()?;
 //! #
-//! # let (carol_state, participant_lists) = DistributedKeyGeneration::<_, Secp256k1Sha256>::bootstrap(&params, &carol_dh_sk, &carol.index, &carol_coefficients,
+//! # let (carol_state, participant_lists) = DistributedKeyGeneration::<_, Secp256k1Sha256>::bootstrap(params, &carol_dh_sk, carol.index, &carol_coefficients,
 //! #                                                      &participants, &mut rng)?;
 //! # let carol_their_encrypted_secret_shares = carol_state.their_encrypted_secret_shares()?;
 //! # let alice_my_encrypted_secret_shares = vec![alice_their_encrypted_secret_shares[0].clone(),
@@ -669,9 +669,9 @@
 //! #                                   bob_their_encrypted_secret_shares[2].clone(),
 //! #                                   carol_their_encrypted_secret_shares[2].clone()];
 //! #
-//! # let alice_state = alice_state.to_round_two(alice_my_encrypted_secret_shares, &mut rng)?;
-//! # let bob_state = bob_state.to_round_two(bob_my_encrypted_secret_shares, &mut rng)?;
-//! # let carol_state = carol_state.to_round_two(carol_my_encrypted_secret_shares, &mut rng)?;
+//! # let alice_state = alice_state.to_round_two(&alice_my_encrypted_secret_shares, &mut rng)?;
+//! # let bob_state = bob_state.to_round_two(&bob_my_encrypted_secret_shares, &mut rng)?;
+//! # let carol_state = carol_state.to_round_two(&carol_my_encrypted_secret_shares, &mut rng)?;
 //! #
 //! # let (alice_group_key, alice_secret_key) = alice_state.finish()?;
 //! # let (bob_group_key, bob_secret_key) = bob_state.finish()?;
@@ -683,31 +683,31 @@
 //! # // Instantiate new configuration parameters and create a set of signers
 //! # let new_params = ThresholdParameters::new(4,3);
 //! #
-//! # let (alexis, alexis_dh_sk) = Participant::new_signer(&new_params, 1, &mut rng)?;
-//! # let (barbara, barbara_dh_sk) = Participant::new_signer(&new_params, 2, &mut rng)?;
-//! # let (claire, claire_dh_sk) = Participant::new_signer(&new_params, 3, &mut rng)?;
-//! # let (david, david_dh_sk) = Participant::new_signer(&new_params, 4, &mut rng)?;
+//! # let (alexis, alexis_dh_sk) = Participant::new_signer(new_params, 1, &mut rng)?;
+//! # let (barbara, barbara_dh_sk) = Participant::new_signer(new_params, 2, &mut rng)?;
+//! # let (claire, claire_dh_sk) = Participant::new_signer(new_params, 3, &mut rng)?;
+//! # let (david, david_dh_sk) = Participant::new_signer(new_params, 4, &mut rng)?;
 //! #
 //! # let signers: Vec<Participant<Secp256k1Sha256>> = vec![alexis.clone(), barbara.clone(), claire.clone(), david.clone()];
 //! # let (alice_as_dealer, alice_encrypted_shares, participant_lists) =
-//! #     Participant::reshare(&new_params, alice_secret_key, &signers, &mut rng)?;
+//! #     Participant::reshare(new_params, &alice_secret_key, &signers, &mut rng)?;
 //! # let (bob_as_dealer, bob_encrypted_shares, participant_lists) =
-//! #     Participant::reshare(&new_params, bob_secret_key, &signers, &mut rng)?;
+//! #     Participant::reshare(new_params, &bob_secret_key, &signers, &mut rng)?;
 //! # let (carol_as_dealer, carol_encrypted_shares, participant_lists) =
-//! #     Participant::reshare(&new_params, carol_secret_key, &signers, &mut rng)?;
+//! #     Participant::reshare(new_params, &carol_secret_key, &signers, &mut rng)?;
 //! #
 //! # let dealers: Vec<Participant<Secp256k1Sha256>> =
 //! #     vec![alice_as_dealer.clone(), bob_as_dealer.clone(), carol_as_dealer.clone()];
-//! # let (alexis_state, participant_lists) = DistributedKeyGeneration::<_, Secp256k1Sha256>::new(&params, &alexis_dh_sk, &alexis.index,
+//! # let (alexis_state, participant_lists) = DistributedKeyGeneration::<_, Secp256k1Sha256>::new(params, &alexis_dh_sk, alexis.index,
 //! #                                                    &dealers, &mut rng)?;
 //! #
-//! # let (barbara_state, participant_lists) = DistributedKeyGeneration::<_, Secp256k1Sha256>::new(&params, &barbara_dh_sk, &barbara.index,
+//! # let (barbara_state, participant_lists) = DistributedKeyGeneration::<_, Secp256k1Sha256>::new(params, &barbara_dh_sk, barbara.index,
 //! #                                                    &dealers, &mut rng)?;
 //! #
-//! # let (claire_state, participant_lists) = DistributedKeyGeneration::<_, Secp256k1Sha256>::new(&params, &claire_dh_sk, &claire.index,
+//! # let (claire_state, participant_lists) = DistributedKeyGeneration::<_, Secp256k1Sha256>::new(params, &claire_dh_sk, claire.index,
 //! #                                                      &dealers, &mut rng)?;
 //! #
-//! # let (david_state, participant_lists) = DistributedKeyGeneration::<_, Secp256k1Sha256>::new(&params, &david_dh_sk, &david.index,
+//! # let (david_state, participant_lists) = DistributedKeyGeneration::<_, Secp256k1Sha256>::new(params, &david_dh_sk, david.index,
 //! #                                                      &dealers, &mut rng)?;
 //! #
 //! # let alexis_my_encrypted_secret_shares = vec![alice_encrypted_shares[0].clone(),
@@ -723,10 +723,10 @@
 //! #                                   bob_encrypted_shares[3].clone(),
 //! #                                   carol_encrypted_shares[3].clone()];
 //! #
-//! let alexis_state = alexis_state.to_round_two(alexis_my_encrypted_secret_shares, &mut rng)?;
-//! let barbara_state = barbara_state.to_round_two(barbara_my_encrypted_secret_shares, &mut rng)?;
-//! let claire_state = claire_state.to_round_two(claire_my_encrypted_secret_shares, &mut rng)?;
-//! let david_state = david_state.to_round_two(david_my_encrypted_secret_shares, &mut rng)?;
+//! let alexis_state = alexis_state.to_round_two(&alexis_my_encrypted_secret_shares, &mut rng)?;
+//! let barbara_state = barbara_state.to_round_two(&barbara_my_encrypted_secret_shares, &mut rng)?;
+//! let claire_state = claire_state.to_round_two(&claire_my_encrypted_secret_shares, &mut rng)?;
+//! let david_state = david_state.to_round_two(&david_my_encrypted_secret_shares, &mut rng)?;
 //! # Ok(()) } fn main() { assert!(do_test().is_ok()); }
 //! ```
 //!
@@ -750,20 +750,20 @@
 //! # let params = ThresholdParameters::new(3,2);
 //! # let mut rng = OsRng;
 //! #
-//! # let (alice, alice_coefficients, alice_dh_sk) = Participant::new_dealer(&params, 1, &mut rng)?;
-//! # let (bob, bob_coefficients, bob_dh_sk) = Participant::new_dealer(&params, 2, &mut rng)?;
-//! # let (carol, carol_coefficients, carol_dh_sk) = Participant::new_dealer(&params, 3, &mut rng)?;
+//! # let (alice, alice_coefficients, alice_dh_sk) = Participant::new_dealer(params, 1, &mut rng)?;
+//! # let (bob, bob_coefficients, bob_dh_sk) = Participant::new_dealer(params, 2, &mut rng)?;
+//! # let (carol, carol_coefficients, carol_dh_sk) = Participant::new_dealer(params, 3, &mut rng)?;
 //! #
 //! # let participants: Vec<Participant<Secp256k1Sha256>> = vec![alice.clone(), bob.clone(), carol.clone()];
-//! # let (alice_state, participant_lists) = DistributedKeyGeneration::<_, Secp256k1Sha256>::bootstrap(&params, &alice_dh_sk, &alice.index, &alice_coefficients,
+//! # let (alice_state, participant_lists) = DistributedKeyGeneration::<_, Secp256k1Sha256>::bootstrap(params, &alice_dh_sk, alice.index, &alice_coefficients,
 //! #                                                      &participants, &mut rng)?;
 //! # let alice_their_encrypted_secret_shares = alice_state.their_encrypted_secret_shares()?;
 //! #
-//! # let (bob_state, participant_lists) = DistributedKeyGeneration::<_, Secp256k1Sha256>::bootstrap(&params, &bob_dh_sk, &bob.index, &bob_coefficients,
+//! # let (bob_state, participant_lists) = DistributedKeyGeneration::<_, Secp256k1Sha256>::bootstrap(params, &bob_dh_sk, bob.index, &bob_coefficients,
 //! #                                                    &participants, &mut rng)?;
 //! # let bob_their_encrypted_secret_shares = bob_state.their_encrypted_secret_shares()?;
 //! #
-//! # let (carol_state, participant_lists) = DistributedKeyGeneration::<_, Secp256k1Sha256>::bootstrap(&params, &carol_dh_sk, &carol.index, &carol_coefficients,
+//! # let (carol_state, participant_lists) = DistributedKeyGeneration::<_, Secp256k1Sha256>::bootstrap(params, &carol_dh_sk, carol.index, &carol_coefficients,
 //! #                                                      &participants, &mut rng)?;
 //! # let carol_their_encrypted_secret_shares = carol_state.their_encrypted_secret_shares()?;
 //! # let alice_my_encrypted_secret_shares = vec![alice_their_encrypted_secret_shares[0].clone(),
@@ -776,9 +776,9 @@
 //! #                                   bob_their_encrypted_secret_shares[2].clone(),
 //! #                                   carol_their_encrypted_secret_shares[2].clone()];
 //! #
-//! # let alice_state = alice_state.to_round_two(alice_my_encrypted_secret_shares, &mut rng)?;
-//! # let bob_state = bob_state.to_round_two(bob_my_encrypted_secret_shares, &mut rng)?;
-//! # let carol_state = carol_state.to_round_two(carol_my_encrypted_secret_shares, &mut rng)?;
+//! # let alice_state = alice_state.to_round_two(&alice_my_encrypted_secret_shares, &mut rng)?;
+//! # let bob_state = bob_state.to_round_two(&bob_my_encrypted_secret_shares, &mut rng)?;
+//! # let carol_state = carol_state.to_round_two(&carol_my_encrypted_secret_shares, &mut rng)?;
 //! #
 //! # let (alice_group_key, alice_secret_key) = alice_state.finish()?;
 //! # let (bob_group_key, bob_secret_key) = bob_state.finish()?;
@@ -789,30 +789,30 @@
 //! #
 //! # let new_params = ThresholdParameters::new(4,3);
 //! #
-//! # let (alexis, alexis_dh_sk) = Participant::new_signer(&new_params, 1, &mut rng)?;
-//! # let (barbara, barbara_dh_sk) = Participant::new_signer(&new_params, 2, &mut rng)?;
-//! # let (claire, claire_dh_sk) = Participant::new_signer(&new_params, 3, &mut rng)?;
-//! # let (david, david_dh_sk) = Participant::new_signer(&new_params, 4, &mut rng)?;
+//! # let (alexis, alexis_dh_sk) = Participant::new_signer(new_params, 1, &mut rng)?;
+//! # let (barbara, barbara_dh_sk) = Participant::new_signer(new_params, 2, &mut rng)?;
+//! # let (claire, claire_dh_sk) = Participant::new_signer(new_params, 3, &mut rng)?;
+//! # let (david, david_dh_sk) = Participant::new_signer(new_params, 4, &mut rng)?;
 //! #
 //! # let signers: Vec<Participant<Secp256k1Sha256>> = vec![alexis.clone(), barbara.clone(), claire.clone(), david.clone()];
 //! # let (alice_as_dealer, alice_encrypted_shares, participant_lists) =
-//! #     Participant::reshare(&new_params, alice_secret_key, &signers, &mut rng)?;
+//! #     Participant::reshare(new_params, &alice_secret_key, &signers, &mut rng)?;
 //! # let (bob_as_dealer, bob_encrypted_shares, participant_lists) =
-//! #     Participant::reshare(&new_params, bob_secret_key, &signers, &mut rng)?;
+//! #     Participant::reshare(new_params, &bob_secret_key, &signers, &mut rng)?;
 //! # let (carol_as_dealer, carol_encrypted_shares, participant_lists) =
-//! #     Participant::reshare(&new_params, carol_secret_key, &signers, &mut rng)?;
+//! #     Participant::reshare(new_params, &carol_secret_key, &signers, &mut rng)?;
 //! #
 //! # let dealers: Vec<Participant<Secp256k1Sha256>> = vec![alice_as_dealer.clone(), bob_as_dealer.clone(), carol_as_dealer.clone()];
-//! # let (alexis_state, participant_lists) = DistributedKeyGeneration::<_, Secp256k1Sha256>::new(&params, &alexis_dh_sk, &alexis.index,
+//! # let (alexis_state, participant_lists) = DistributedKeyGeneration::<_, Secp256k1Sha256>::new(params, &alexis_dh_sk, alexis.index,
 //! #                                                    &dealers, &mut rng)?;
 //! #
-//! # let (barbara_state, participant_lists) = DistributedKeyGeneration::<_, Secp256k1Sha256>::new(&params, &barbara_dh_sk, &barbara.index,
+//! # let (barbara_state, participant_lists) = DistributedKeyGeneration::<_, Secp256k1Sha256>::new(params, &barbara_dh_sk, barbara.index,
 //! #                                                    &dealers, &mut rng)?;
 //! #
-//! # let (claire_state, participant_lists) = DistributedKeyGeneration::<_, Secp256k1Sha256>::new(&params, &claire_dh_sk, &claire.index,
+//! # let (claire_state, participant_lists) = DistributedKeyGeneration::<_, Secp256k1Sha256>::new(params, &claire_dh_sk, claire.index,
 //! #                                                      &dealers, &mut rng)?;
 //! #
-//! # let (david_state, participant_lists) = DistributedKeyGeneration::<_, Secp256k1Sha256>::new(&params, &david_dh_sk, &david.index,
+//! # let (david_state, participant_lists) = DistributedKeyGeneration::<_, Secp256k1Sha256>::new(params, &david_dh_sk, david.index,
 //! #                                                      &dealers, &mut rng)?;
 //! #
 //! # let alexis_my_encrypted_secret_shares = vec![alice_encrypted_shares[0].clone(),
@@ -828,10 +828,10 @@
 //! #                                   bob_encrypted_shares[3].clone(),
 //! #                                   carol_encrypted_shares[3].clone()];
 //! #
-//! # let alexis_state = alexis_state.to_round_two(alexis_my_encrypted_secret_shares, &mut rng)?;
-//! # let barbara_state = barbara_state.to_round_two(barbara_my_encrypted_secret_shares, &mut rng)?;
-//! # let claire_state = claire_state.to_round_two(claire_my_encrypted_secret_shares, &mut rng)?;
-//! # let david_state = david_state.to_round_two(david_my_encrypted_secret_shares, &mut rng)?;
+//! # let alexis_state = alexis_state.to_round_two(&alexis_my_encrypted_secret_shares, &mut rng)?;
+//! # let barbara_state = barbara_state.to_round_two(&barbara_my_encrypted_secret_shares, &mut rng)?;
+//! # let claire_state = claire_state.to_round_two(&claire_my_encrypted_secret_shares, &mut rng)?;
+//! # let david_state = david_state.to_round_two(&david_my_encrypted_secret_shares, &mut rng)?;
 //! #
 //! let (alexis_group_key, alexis_secret_key) = alexis_state.finish()?;
 //! let (barbara_group_key, barbara_secret_key) = barbara_state.finish()?;
@@ -869,20 +869,20 @@
 //! # let params = ThresholdParameters::new(3,2);
 //! # let mut rng = OsRng;
 //! #
-//! # let (alice, alice_coefficients, alice_dh_sk) = Participant::new_dealer(&params, 1, &mut rng)?;
-//! # let (bob, bob_coefficients, bob_dh_sk) = Participant::new_dealer(&params, 2, &mut rng)?;
-//! # let (carol, carol_coefficients, carol_dh_sk) = Participant::new_dealer(&params, 3, &mut rng)?;
+//! # let (alice, alice_coefficients, alice_dh_sk) = Participant::new_dealer(params, 1, &mut rng)?;
+//! # let (bob, bob_coefficients, bob_dh_sk) = Participant::new_dealer(params, 2, &mut rng)?;
+//! # let (carol, carol_coefficients, carol_dh_sk) = Participant::new_dealer(params, 3, &mut rng)?;
 //! #
 //! # let participants: Vec<Participant<Secp256k1Sha256>> = vec![alice.clone(), bob.clone(), carol.clone()];
-//! # let (alice_state, participant_lists) = DistributedKeyGeneration::<_, Secp256k1Sha256>::bootstrap(&params, &alice_dh_sk, &alice.index, &alice_coefficients,
+//! # let (alice_state, participant_lists) = DistributedKeyGeneration::<_, Secp256k1Sha256>::bootstrap(params, &alice_dh_sk, alice.index, &alice_coefficients,
 //! #                                                      &participants, &mut rng)?;
 //! # let alice_their_encrypted_secret_shares = alice_state.their_encrypted_secret_shares()?;
 //! #
-//! # let (bob_state, participant_lists) = DistributedKeyGeneration::<_, Secp256k1Sha256>::bootstrap(&params, &bob_dh_sk, &bob.index, &bob_coefficients,
+//! # let (bob_state, participant_lists) = DistributedKeyGeneration::<_, Secp256k1Sha256>::bootstrap(params, &bob_dh_sk, bob.index, &bob_coefficients,
 //! #                                                    &participants, &mut rng)?;
 //! # let bob_their_encrypted_secret_shares = bob_state.their_encrypted_secret_shares()?;
 //! #
-//! # let (carol_state, participant_lists) = DistributedKeyGeneration::<_, Secp256k1Sha256>::bootstrap(&params, &carol_dh_sk, &carol.index, &carol_coefficients,
+//! # let (carol_state, participant_lists) = DistributedKeyGeneration::<_, Secp256k1Sha256>::bootstrap(params, &carol_dh_sk, carol.index, &carol_coefficients,
 //! #                                                      &participants, &mut rng)?;
 //! # let carol_their_encrypted_secret_shares = carol_state.their_encrypted_secret_shares()?;
 //! # let alice_my_encrypted_secret_shares = vec![alice_their_encrypted_secret_shares[0].clone(),
@@ -895,9 +895,9 @@
 //! #                                   bob_their_encrypted_secret_shares[2].clone(),
 //! #                                   carol_their_encrypted_secret_shares[2].clone()];
 //! #
-//! # let alice_state = alice_state.to_round_two(alice_my_encrypted_secret_shares, &mut rng)?;
-//! # let bob_state = bob_state.to_round_two(bob_my_encrypted_secret_shares, &mut rng)?;
-//! # let carol_state = carol_state.to_round_two(carol_my_encrypted_secret_shares, &mut rng)?;
+//! # let alice_state = alice_state.to_round_two(&alice_my_encrypted_secret_shares, &mut rng)?;
+//! # let bob_state = bob_state.to_round_two(&bob_my_encrypted_secret_shares, &mut rng)?;
+//! # let carol_state = carol_state.to_round_two(&carol_my_encrypted_secret_shares, &mut rng)?;
 //! #
 //! # let (alice_group_key, alice_secret_key) = alice_state.finish()?;
 //! # let (bob_group_key, bob_secret_key) = bob_state.finish()?;
@@ -948,20 +948,20 @@
 //! # let params = ThresholdParameters::new(3,2);
 //! # let mut rng = OsRng;
 //! #
-//! # let (alice, alice_coefficients, alice_dh_sk) = Participant::new_dealer(&params, 1, &mut rng)?;
-//! # let (bob, bob_coefficients, bob_dh_sk) = Participant::new_dealer(&params, 2, &mut rng)?;
-//! # let (carol, carol_coefficients, carol_dh_sk) = Participant::new_dealer(&params, 3, &mut rng)?;
+//! # let (alice, alice_coefficients, alice_dh_sk) = Participant::new_dealer(params, 1, &mut rng)?;
+//! # let (bob, bob_coefficients, bob_dh_sk) = Participant::new_dealer(params, 2, &mut rng)?;
+//! # let (carol, carol_coefficients, carol_dh_sk) = Participant::new_dealer(params, 3, &mut rng)?;
 //! #
 //! # let participants: Vec<Participant<Secp256k1Sha256>> = vec![alice.clone(), bob.clone(), carol.clone()];
-//! # let (alice_state, participant_lists) = DistributedKeyGeneration::<_, Secp256k1Sha256>::bootstrap(&params, &alice_dh_sk, &alice.index, &alice_coefficients,
+//! # let (alice_state, participant_lists) = DistributedKeyGeneration::<_, Secp256k1Sha256>::bootstrap(params, &alice_dh_sk, alice.index, &alice_coefficients,
 //! #                                                      &participants, &mut rng)?;
 //! # let alice_their_encrypted_secret_shares = alice_state.their_encrypted_secret_shares()?;
 //! #
-//! # let (bob_state, participant_lists) = DistributedKeyGeneration::<_, Secp256k1Sha256>::bootstrap(&params, &bob_dh_sk, &bob.index, &bob_coefficients,
+//! # let (bob_state, participant_lists) = DistributedKeyGeneration::<_, Secp256k1Sha256>::bootstrap(params, &bob_dh_sk, bob.index, &bob_coefficients,
 //! #                                                    &participants, &mut rng)?;
 //! # let bob_their_encrypted_secret_shares = bob_state.their_encrypted_secret_shares()?;
 //! #
-//! # let (carol_state, participant_lists) = DistributedKeyGeneration::<_, Secp256k1Sha256>::bootstrap(&params, &carol_dh_sk, &carol.index, &carol_coefficients,
+//! # let (carol_state, participant_lists) = DistributedKeyGeneration::<_, Secp256k1Sha256>::bootstrap(params, &carol_dh_sk, carol.index, &carol_coefficients,
 //! #                                                      &participants, &mut rng)?;
 //! # let carol_their_encrypted_secret_shares = carol_state.their_encrypted_secret_shares()?;
 //! # let alice_my_encrypted_secret_shares = vec![alice_their_encrypted_secret_shares[0].clone(),
@@ -974,9 +974,9 @@
 //! #                                   bob_their_encrypted_secret_shares[2].clone(),
 //! #                                   carol_their_encrypted_secret_shares[2].clone()];
 //! #
-//! # let alice_state = alice_state.to_round_two(alice_my_encrypted_secret_shares, &mut rng)?;
-//! # let bob_state = bob_state.to_round_two(bob_my_encrypted_secret_shares, &mut rng)?;
-//! # let carol_state = carol_state.to_round_two(carol_my_encrypted_secret_shares, &mut rng)?;
+//! # let alice_state = alice_state.to_round_two(&alice_my_encrypted_secret_shares, &mut rng)?;
+//! # let bob_state = bob_state.to_round_two(&bob_my_encrypted_secret_shares, &mut rng)?;
+//! # let carol_state = carol_state.to_round_two(&carol_my_encrypted_secret_shares, &mut rng)?;
 //! #
 //! # let (alice_group_key, alice_secret_key) = alice_state.finish()?;
 //! # let (bob_group_key, bob_secret_key) = bob_state.finish()?;
@@ -997,8 +997,8 @@
 //! #
 //! # let mut aggregator = SignatureAggregator::new(params, bob_group_key.clone(), &message[..]);
 //! #
-//! aggregator.include_signer(1, alice_public_comshares.commitments[0], alice_public_key);
-//! aggregator.include_signer(3, carol_public_comshares.commitments[0], carol_public_key);
+//! aggregator.include_signer(1, alice_public_comshares.commitments[0], &alice_public_key);
+//! aggregator.include_signer(3, carol_public_comshares.commitments[0], &carol_public_key);
 //! # Ok(()) }
 //! # fn main() { assert!(do_test().is_ok()); }
 //! ```
@@ -1022,20 +1022,20 @@
 //! # let params = ThresholdParameters::new(3,2);
 //! # let mut rng = OsRng;
 //! #
-//! # let (alice, alice_coefficients, alice_dh_sk) = Participant::new_dealer(&params, 1, &mut rng)?;
-//! # let (bob, bob_coefficients, bob_dh_sk) = Participant::new_dealer(&params, 2, &mut rng)?;
-//! # let (carol, carol_coefficients, carol_dh_sk) = Participant::new_dealer(&params, 3, &mut rng)?;
+//! # let (alice, alice_coefficients, alice_dh_sk) = Participant::new_dealer(params, 1, &mut rng)?;
+//! # let (bob, bob_coefficients, bob_dh_sk) = Participant::new_dealer(params, 2, &mut rng)?;
+//! # let (carol, carol_coefficients, carol_dh_sk) = Participant::new_dealer(params, 3, &mut rng)?;
 //! #
 //! # let participants: Vec<Participant<Secp256k1Sha256>> = vec![alice.clone(), bob.clone(), carol.clone()];
-//! # let (alice_state, participant_lists) = DistributedKeyGeneration::<_, Secp256k1Sha256>::bootstrap(&params, &alice_dh_sk, &alice.index, &alice_coefficients,
+//! # let (alice_state, participant_lists) = DistributedKeyGeneration::<_, Secp256k1Sha256>::bootstrap(params, &alice_dh_sk, alice.index, &alice_coefficients,
 //! #                                                      &participants, &mut rng)?;
 //! # let alice_their_encrypted_secret_shares = alice_state.their_encrypted_secret_shares()?;
 //! #
-//! # let (bob_state, participant_lists) = DistributedKeyGeneration::<_, Secp256k1Sha256>::bootstrap(&params, &bob_dh_sk, &bob.index, &bob_coefficients,
+//! # let (bob_state, participant_lists) = DistributedKeyGeneration::<_, Secp256k1Sha256>::bootstrap(params, &bob_dh_sk, bob.index, &bob_coefficients,
 //! #                                                    &participants, &mut rng)?;
 //! # let bob_their_encrypted_secret_shares = bob_state.their_encrypted_secret_shares()?;
 //! #
-//! # let (carol_state, participant_lists) = DistributedKeyGeneration::<_, Secp256k1Sha256>::bootstrap(&params, &carol_dh_sk, &carol.index, &carol_coefficients,
+//! # let (carol_state, participant_lists) = DistributedKeyGeneration::<_, Secp256k1Sha256>::bootstrap(params, &carol_dh_sk, carol.index, &carol_coefficients,
 //! #                                                      &participants, &mut rng)?;
 //! # let carol_their_encrypted_secret_shares = carol_state.their_encrypted_secret_shares()?;
 //! # let alice_my_encrypted_secret_shares = vec![alice_their_encrypted_secret_shares[0].clone(),
@@ -1048,9 +1048,9 @@
 //! #                                   bob_their_encrypted_secret_shares[2].clone(),
 //! #                                   carol_their_encrypted_secret_shares[2].clone()];
 //! #
-//! # let alice_state = alice_state.to_round_two(alice_my_encrypted_secret_shares, &mut rng)?;
-//! # let bob_state = bob_state.to_round_two(bob_my_encrypted_secret_shares, &mut rng)?;
-//! # let carol_state = carol_state.to_round_two(carol_my_encrypted_secret_shares, &mut rng)?;
+//! # let alice_state = alice_state.to_round_two(&alice_my_encrypted_secret_shares, &mut rng)?;
+//! # let bob_state = bob_state.to_round_two(&bob_my_encrypted_secret_shares, &mut rng)?;
+//! # let carol_state = carol_state.to_round_two(&carol_my_encrypted_secret_shares, &mut rng)?;
 //! #
 //! # let (alice_group_key, alice_secret_key) = alice_state.finish()?;
 //! # let (bob_group_key, bob_secret_key) = bob_state.finish()?;
@@ -1071,8 +1071,8 @@
 //! #
 //! # let mut aggregator = SignatureAggregator::new(params, bob_group_key.clone(), &message[..]);
 //! #
-//! # aggregator.include_signer(1, alice_public_comshares.commitments[0], alice_public_key);
-//! # aggregator.include_signer(3, carol_public_comshares.commitments[0], carol_public_key);
+//! # aggregator.include_signer(1, alice_public_comshares.commitments[0], &alice_public_key);
+//! # aggregator.include_signer(3, carol_public_comshares.commitments[0], &carol_public_key);
 //! let signers = aggregator.get_signers();
 //! # Ok(()) }
 //! # fn main() { assert!(do_test().is_ok()); }
@@ -1096,20 +1096,20 @@
 //! # let params = ThresholdParameters::new(3,2);
 //! # let mut rng = OsRng;
 //! #
-//! # let (alice, alice_coefficients, alice_dh_sk) = Participant::new_dealer(&params, 1, &mut rng)?;
-//! # let (bob, bob_coefficients, bob_dh_sk) = Participant::new_dealer(&params, 2, &mut rng)?;
-//! # let (carol, carol_coefficients, carol_dh_sk) = Participant::new_dealer(&params, 3, &mut rng)?;
+//! # let (alice, alice_coefficients, alice_dh_sk) = Participant::new_dealer(params, 1, &mut rng)?;
+//! # let (bob, bob_coefficients, bob_dh_sk) = Participant::new_dealer(params, 2, &mut rng)?;
+//! # let (carol, carol_coefficients, carol_dh_sk) = Participant::new_dealer(params, 3, &mut rng)?;
 //! #
 //! # let participants: Vec<Participant<Secp256k1Sha256>> = vec![alice.clone(), bob.clone(), carol.clone()];
-//! # let (alice_state, participant_lists) = DistributedKeyGeneration::<_, Secp256k1Sha256>::bootstrap(&params, &alice_dh_sk, &alice.index, &alice_coefficients,
+//! # let (alice_state, participant_lists) = DistributedKeyGeneration::<_, Secp256k1Sha256>::bootstrap(params, &alice_dh_sk, alice.index, &alice_coefficients,
 //! #                                                      &participants, &mut rng)?;
 //! # let alice_their_encrypted_secret_shares = alice_state.their_encrypted_secret_shares()?;
 //! #
-//! # let (bob_state, participant_lists) = DistributedKeyGeneration::<_, Secp256k1Sha256>::bootstrap(&params, &bob_dh_sk, &bob.index, &bob_coefficients,
+//! # let (bob_state, participant_lists) = DistributedKeyGeneration::<_, Secp256k1Sha256>::bootstrap(params, &bob_dh_sk, bob.index, &bob_coefficients,
 //! #                                                    &participants, &mut rng)?;
 //! # let bob_their_encrypted_secret_shares = bob_state.their_encrypted_secret_shares()?;
 //! #
-//! # let (carol_state, participant_lists) = DistributedKeyGeneration::<_, Secp256k1Sha256>::bootstrap(&params, &carol_dh_sk, &carol.index, &carol_coefficients,
+//! # let (carol_state, participant_lists) = DistributedKeyGeneration::<_, Secp256k1Sha256>::bootstrap(params, &carol_dh_sk, carol.index, &carol_coefficients,
 //! #                                                      &participants, &mut rng)?;
 //! # let carol_their_encrypted_secret_shares = carol_state.their_encrypted_secret_shares()?;
 //! # let alice_my_encrypted_secret_shares = vec![alice_their_encrypted_secret_shares[0].clone(),
@@ -1122,9 +1122,9 @@
 //! #                                   bob_their_encrypted_secret_shares[2].clone(),
 //! #                                   carol_their_encrypted_secret_shares[2].clone()];
 //! #
-//! # let alice_state = alice_state.to_round_two(alice_my_encrypted_secret_shares, &mut rng)?;
-//! # let bob_state = bob_state.to_round_two(bob_my_encrypted_secret_shares, &mut rng)?;
-//! # let carol_state = carol_state.to_round_two(carol_my_encrypted_secret_shares, &mut rng)?;
+//! # let alice_state = alice_state.to_round_two(&alice_my_encrypted_secret_shares, &mut rng)?;
+//! # let bob_state = bob_state.to_round_two(&bob_my_encrypted_secret_shares, &mut rng)?;
+//! # let carol_state = carol_state.to_round_two(&carol_my_encrypted_secret_shares, &mut rng)?;
 //! #
 //! # let (alice_group_key, alice_secret_key) = alice_state.finish()?;
 //! # let (bob_group_key, bob_secret_key) = bob_state.finish()?;
@@ -1145,11 +1145,11 @@
 //! #
 //! # let mut aggregator = SignatureAggregator::new(params, bob_group_key.clone(), &message[..]);
 //! #
-//! # aggregator.include_signer(1, alice_public_comshares.commitments[0], (&alice_secret_key).into());
-//! # aggregator.include_signer(3, carol_public_comshares.commitments[0], (&carol_secret_key).into());
+//! # aggregator.include_signer(1, alice_public_comshares.commitments[0], &alice_public_key);
+//! # aggregator.include_signer(3, carol_public_comshares.commitments[0], &carol_public_key);
 //! #
 //! # let signers = aggregator.get_signers();
-//! # let message_hash = Secp256k1Sha256::h4(&message[..]).unwrap();
+//! # let message_hash = Secp256k1Sha256::h4(&message[..]);
 //!
 //! let alice_partial = alice_secret_key.sign(
 //!     &message_hash,
@@ -1166,8 +1166,8 @@
 //!     signers
 //! )?;
 //!
-//! aggregator.include_partial_signature(alice_partial);
-//! aggregator.include_partial_signature(carol_partial);
+//! aggregator.include_partial_signature(&alice_partial);
+//! aggregator.include_partial_signature(&carol_partial);
 //! # Ok(()) }
 //! # fn main() { assert!(do_test().is_ok()); }
 //! ```
@@ -1249,11 +1249,11 @@ pub mod dkg;
 /// A module defining the logic of an ICE-FROST signing session.
 pub mod sign;
 
-/// This module provides a concrete implementation of an ICE-FROST CipherSuite over Secp256k1,
+/// This module provides a concrete implementation of an ICE-FROST [`CipherSuite`] over Secp256k1,
 /// with SHA-256 as underlying base hash function.
 /// It is made available for testing and benchmarking purposes.
 pub mod testing {
-    use super::*;
+    use super::{utils, CipherSuite};
 
     use ark_secp256k1::Projective as G;
 

--- a/src/parameters.rs
+++ b/src/parameters.rs
@@ -28,6 +28,7 @@ impl<C: CipherSuite> ThresholdParameters<C> {
     ///  - n equals 0
     ///  - t equals 0
     ///  - n < t
+    #[must_use]
     pub fn new(n: u32, t: u32) -> Self {
         assert!(n > 0);
         assert!(t > 0);

--- a/src/sign/precomputation.rs
+++ b/src/sign/precomputation.rs
@@ -30,7 +30,8 @@ fn nonce_generate<C: CipherSuite>(
 
     let mut nonce_input = random_bytes.as_ref().to_vec();
     nonce_input.extend(&secret_key.to_bytes()?);
-    C::h3(&nonce_input)
+
+    Ok(C::h3(&nonce_input))
 }
 
 #[derive(Debug, CanonicalSerialize, CanonicalDeserialize, Zeroize)]
@@ -188,7 +189,7 @@ pub fn generate_commitment_share_lists<C: CipherSuite>(
 
     let mut published: Vec<(C::G, C::G)> = Vec::with_capacity(number_of_shares);
 
-    for commitment in commitments.iter() {
+    for commitment in &commitments {
         published.push(commitment.publish());
     }
 
@@ -276,7 +277,7 @@ mod test {
             let commit = Projective::generator().mul(secret);
             let binding = Commitment::<Secp256k1Sha256> { secret, commit };
             let hiding = binding.clone();
-            let commitment_share = CommitmentShare { binding, hiding };
+            let commitment_share = CommitmentShare { hiding, binding };
             let mut bytes = Vec::with_capacity(commitment_share.compressed_size());
 
             commitment_share.serialize_compressed(&mut bytes).unwrap();

--- a/src/sign/signature.rs
+++ b/src/sign/signature.rs
@@ -150,7 +150,7 @@ impl<C: CipherSuite> DerefMut for IndividualPublicKeys<C> {
 fn encode_group_commitment_list<C: CipherSuite>(commitment_list: &[(u32, C::G, C::G)]) -> Vec<u8> {
     let mut encoded_group_commitment =
         Vec::with_capacity(commitment_list.len() * 2 * commitment_list[0].1.compressed_size());
-    for (identifier, hiding_nonce_commitment, binding_nonce_commitment) in commitment_list.iter() {
+    for (identifier, hiding_nonce_commitment, binding_nonce_commitment) in commitment_list {
         // RFC Note: identifier should be a ScalarField element that we serialize
         encoded_group_commitment.extend(&identifier.to_le_bytes()[..]);
         hiding_nonce_commitment
@@ -167,39 +167,39 @@ fn encode_group_commitment_list<C: CipherSuite>(commitment_list: &[(u32, C::G, C
 fn compute_binding_factors<C: CipherSuite>(
     message: &[u8],
     signers: &[Signer<C>],
-) -> FrostResult<C, BindingFactors<C>> {
+) -> BindingFactors<C> {
     let mut binding_factor_list = BindingFactors::new();
 
-    let mut msg_hash = C::h4(message)?.as_ref().to_vec();
+    let mut msg_hash = C::h4(message).as_ref().to_vec();
 
     let mut commitment_list = Vec::with_capacity(signers.len());
-    for signer in signers.iter() {
+    for signer in signers {
         let hiding = signer.published_commitment_share.0;
         let binding = signer.published_commitment_share.1;
 
         commitment_list.push((signer.participant_index, hiding, binding));
     }
 
-    let encoded_comm_hash = C::h5(&encode_group_commitment_list::<C>(&commitment_list))?;
+    let encoded_comm_hash = C::h5(&encode_group_commitment_list::<C>(&commitment_list));
     // [`extend`] operates in place, hence msg_hash is now equal to [`rho_input_prefix`] .
     msg_hash.extend(encoded_comm_hash.as_ref());
 
-    for (identifier, _, _) in commitment_list.iter() {
+    for (identifier, _, _) in &commitment_list {
         let mut rho_input = msg_hash.clone();
         // RFC Note: identifier should be a ScalarField element that we serialize
         rho_input.extend(&identifier.to_le_bytes()[..]);
-        let binding_factor = C::h1(&rho_input)?;
+        let binding_factor = C::h1(&rho_input);
         binding_factor_list.insert(*identifier, binding_factor);
     }
 
-    Ok(binding_factor_list)
+    binding_factor_list
 }
 
 fn binding_factor_for_participant<C: CipherSuite>(
     participant_index: u32,
     binding_factor_list: &BTreeMap<u32, Scalar<C>>,
 ) -> Scalar<C> {
-    for (i, binding_factor) in binding_factor_list.iter() {
+    for (i, binding_factor) in binding_factor_list {
         if participant_index == *i {
             return *binding_factor;
         }
@@ -212,12 +212,12 @@ fn commitment_for_participant<C: CipherSuite>(
     participant_index: u32,
     message: &[u8],
     signers: &[Signer<C>],
-) -> FrostResult<C, C::G> {
-    let mut msg_hash = C::h4(message)?.as_ref().to_vec();
+) -> C::G {
+    let mut msg_hash = C::h4(message).as_ref().to_vec();
 
     let mut commitment_list = Vec::with_capacity(signers.len());
     let (mut participant_hiding, mut participant_binding) = (C::G::zero(), C::G::zero());
-    for signer in signers.iter() {
+    for signer in signers {
         let hiding = signer.published_commitment_share.0;
         let binding = signer.published_commitment_share.1;
 
@@ -228,16 +228,16 @@ fn commitment_for_participant<C: CipherSuite>(
         }
     }
 
-    let encoded_comm_hash = C::h5(&encode_group_commitment_list::<C>(&commitment_list))?;
+    let encoded_comm_hash = C::h5(&encode_group_commitment_list::<C>(&commitment_list));
     // [`extend`] operates in place, hence msg_hash is now equal to [`rho_input_prefix`] .
     msg_hash.extend(encoded_comm_hash.as_ref());
 
     let mut rho_input = msg_hash.clone();
     // RFC Note: identifier should be a ScalarField element that we serialize
     rho_input.extend(&participant_index.to_le_bytes()[..]);
-    let binding_factor = C::h1(&rho_input)?;
+    let binding_factor = C::h1(&rho_input);
 
-    Ok(participant_hiding + participant_binding.mul(binding_factor))
+    participant_hiding + participant_binding.mul(binding_factor)
 }
 
 fn compute_group_commitment<C: CipherSuite>(
@@ -246,7 +246,7 @@ fn compute_group_commitment<C: CipherSuite>(
 ) -> C::G {
     let mut group_commitment = C::G::zero();
 
-    for signer in signers.iter() {
+    for signer in signers {
         let hiding_nonce_commitment = signer.published_commitment_share.0;
         let binding_nonce_commitment = signer.published_commitment_share.1;
 
@@ -275,7 +275,7 @@ pub(crate) fn compute_challenge<C: CipherSuite>(
         .map_err(|_| Error::CompressionError)?;
     challenge_input.extend(message_hash);
 
-    Ok(C::h2(&challenge_input).unwrap())
+    Ok(C::h2(&challenge_input))
 }
 
 impl<C: CipherSuite> IndividualSigningKey<C> {
@@ -285,7 +285,7 @@ impl<C: CipherSuite> IndividualSigningKey<C> {
     /// # Inputs
     ///
     /// * The `message_hash` to be signed by every individual signer. This can be computed
-    ///   with the `h4` hasher of this instantiation's CipherSuite.
+    ///   with the `h4` hasher of this instantiation's [`CipherSuite`].
     /// * The public [`GroupVerifyingKey`] for this group of signing participants,
     /// * This signer's [`SecretCommitmentShareList`] being used in this instantiation and
     /// * The index of the particular `CommitmentShare` being used, and
@@ -313,7 +313,7 @@ impl<C: CipherSuite> IndividualSigningKey<C> {
             return Err(Error::MissingCommitmentShares);
         }
 
-        let binding_factor_list = compute_binding_factors(message_hash, signers)?;
+        let binding_factor_list = compute_binding_factors(message_hash, signers);
         let binding_factor = binding_factor_for_participant::<C>(self.index, &binding_factor_list);
 
         let group_commitment = compute_group_commitment(signers, &binding_factor_list);
@@ -461,7 +461,7 @@ impl<C: CipherSuite> SignatureAggregator<C, Initial<'_>> {
         &mut self,
         participant_index: u32,
         published_commitment_share: (C::G, C::G),
-        public_key: IndividualVerifyingKey<C>,
+        public_key: &IndividualVerifyingKey<C>,
     ) {
         assert_eq!(participant_index, public_key.index,
                    "Tried to add signer with participant index {}, but public key is for participant with index {}",
@@ -503,10 +503,11 @@ impl<C: CipherSuite> SignatureAggregator<C, Initial<'_>> {
     ///
     /// A sorted [`Vec`] of unique [`Signer`]s who have yet to contribute their
     /// partial signatures.
+    #[must_use]
     pub fn get_remaining_signers(&self) -> Vec<Signer<C>> {
         let mut remaining_signers = Vec::with_capacity(self.state.signers.len());
 
-        for signer in self.state.signers.iter() {
+        for signer in &self.state.signers {
             if self
                 .state
                 .partial_signatures
@@ -522,7 +523,7 @@ impl<C: CipherSuite> SignatureAggregator<C, Initial<'_>> {
     }
 
     /// Add a [`PartialThresholdSignature`] to be included in the aggregation.
-    pub fn include_partial_signature(&mut self, partial_signature: PartialThresholdSignature<C>) {
+    pub fn include_partial_signature(&mut self, partial_signature: &PartialThresholdSignature<C>) {
         self.state
             .partial_signatures
             .insert(partial_signature.index, partial_signature.z);
@@ -550,7 +551,7 @@ impl<C: CipherSuite> SignatureAggregator<C, Initial<'_>> {
             // We call the aggregator "participant 0" for the sake of error messages.
             misbehaving_participants.push(0);
 
-            for signer in remaining_signers.iter() {
+            for signer in &remaining_signers {
                 misbehaving_participants.push(signer.participant_index);
             }
         }
@@ -558,7 +559,7 @@ impl<C: CipherSuite> SignatureAggregator<C, Initial<'_>> {
         // Ensure that our new state is ordered and deduplicated.
         self.state.signers = self.get_signers().clone();
 
-        for signer in self.state.signers.iter() {
+        for signer in &self.state.signers {
             if self
                 .state
                 .public_keys
@@ -573,7 +574,7 @@ impl<C: CipherSuite> SignatureAggregator<C, Initial<'_>> {
             return Err(Error::MisbehavingParticipants(misbehaving_participants));
         }
 
-        let message_hash = C::h4(self.aggregator.message)?;
+        let message_hash = C::h4(self.aggregator.message);
 
         Ok(SignatureAggregator {
             state: self.state,
@@ -592,7 +593,7 @@ impl<C: CipherSuite> SignatureAggregator<C, Finalized<C>> {
     /// signers and a description of their misbehaviour.
     pub fn aggregate(&self) -> FrostResult<C, ThresholdSignature<C>> {
         let binding_factor_list =
-            compute_binding_factors(self.aggregator.message_hash.as_ref(), &self.state.signers)?;
+            compute_binding_factors(self.aggregator.message_hash.as_ref(), &self.state.signers);
         let group_commitment = compute_group_commitment(&self.state.signers, &binding_factor_list);
         let challenge = compute_challenge::<C>(
             &group_commitment,
@@ -611,7 +612,7 @@ impl<C: CipherSuite> SignatureAggregator<C, Finalized<C>> {
 
         // We first combine all partial signatures together, to remove the need for individual
         // signature verification in case the final group signature is valid.
-        for signer in self.state.signers.iter() {
+        for signer in &self.state.signers {
             // This unwrap() cannot fail, because [`SignatureAggregator<Initial>::finalize()`]
             // checks that we have partial signature for every expected signer.
             let partial_sig = self
@@ -624,59 +625,59 @@ impl<C: CipherSuite> SignatureAggregator<C, Finalized<C>> {
         }
 
         let signature = ThresholdSignature {
-            z,
             group_commitment,
+            z,
         };
 
         // Verify the obtained signature, listing malicious participants
         // if the verification failed.
-        match signature.verify(&self.state.group_key, self.aggregator.message_hash.as_ref()) {
-            Ok(()) => Ok(signature),
-            Err(_) => {
-                let mut misbehaving_participants = Vec::new();
-                for signer in self.state.signers.iter() {
-                    // This unwrap() cannot fail, since the attempted division by zero in
-                    // the calculation of the Lagrange interpolation cannot happen,
-                    // because we use the typestate pattern,
-                    // i.e. [`SignatureAggregator<Initial>::finalize()`], to ensure that
-                    // there are no duplicate signers, which is the only thing that
-                    // would cause a denominator of zero.
-                    let lambda = calculate_lagrange_coefficients::<C>(
-                        signer.participant_index,
-                        &all_participant_indices,
-                    )
+        if let Ok(()) =
+            signature.verify(&self.state.group_key, self.aggregator.message_hash.as_ref())
+        {
+            Ok(signature)
+        } else {
+            let mut misbehaving_participants = Vec::new();
+            for signer in &self.state.signers {
+                // This unwrap() cannot fail, since the attempted division by zero in
+                // the calculation of the Lagrange interpolation cannot happen,
+                // because we use the typestate pattern,
+                // i.e. [`SignatureAggregator<Initial>::finalize()`], to ensure that
+                // there are no duplicate signers, which is the only thing that
+                // would cause a denominator of zero.
+                let lambda = calculate_lagrange_coefficients::<C>(
+                    signer.participant_index,
+                    &all_participant_indices,
+                )
+                .unwrap();
+
+                // This cannot fail, and has already been performed previously.
+                let partial_sig = self
+                    .state
+                    .partial_signatures
+                    .get(&signer.participant_index)
                     .unwrap();
 
-                    // This cannot fail, and has already been performed previously.
-                    let partial_sig = self
-                        .state
-                        .partial_signatures
-                        .get(&signer.participant_index)
-                        .unwrap();
-
-                    // This cannot fail, as it is checked when calling finalize().
-                    let pk_i = self
-                        .state
-                        .public_keys
-                        .get(&signer.participant_index)
-                        .unwrap();
-
-                    let check = C::G::generator() * partial_sig;
-
-                    // This cannot fail, as the group commitment has already been computed.
-                    let participant_commitment = commitment_for_participant(
-                        signer.participant_index,
-                        self.aggregator.message_hash.as_ref(),
-                        &self.state.signers,
-                    )
+                // This cannot fail, as it is checked when calling finalize().
+                let pk_i = self
+                    .state
+                    .public_keys
+                    .get(&signer.participant_index)
                     .unwrap();
 
-                    if check != participant_commitment + (pk_i.mul(challenge * lambda)) {
-                        misbehaving_participants.push(signer.participant_index);
-                    }
+                let check = C::G::generator() * partial_sig;
+
+                // This cannot fail, as the group commitment has already been computed.
+                let participant_commitment = commitment_for_participant(
+                    signer.participant_index,
+                    self.aggregator.message_hash.as_ref(),
+                    &self.state.signers,
+                );
+
+                if check != participant_commitment + (pk_i.mul(challenge * lambda)) {
+                    misbehaving_participants.push(signer.participant_index);
                 }
-                Err(Error::MisbehavingParticipants(misbehaving_participants))
             }
+            Err(Error::MisbehavingParticipants(misbehaving_participants))
         }
     }
 }
@@ -701,9 +702,10 @@ impl<C: CipherSuite> ThresholdSignature<C> {
         )
         .map_err(|_| Error::InvalidSignature)?;
 
-        match self.group_commitment == retrieved_commitment {
-            true => Ok(()),
-            false => Err(Error::InvalidSignature),
+        if self.group_commitment == retrieved_commitment {
+            Ok(())
+        } else {
+            Err(Error::InvalidSignature)
         }
     }
 }
@@ -748,9 +750,8 @@ mod test {
         let mut coefficients = Vec::<Coefficients<Secp256k1Sha256>>::new();
         let mut dh_secret_keys = Vec::<DiffieHellmanPrivateKey<Secp256k1Sha256>>::new();
 
-        for i in 1..n1 + 1 {
-            let (p, c, dh_sk) =
-                Participant::<Secp256k1Sha256>::new_dealer(&params, i, rng).unwrap();
+        for i in 1..=n1 {
+            let (p, c, dh_sk) = Participant::<Secp256k1Sha256>::new_dealer(params, i, rng).unwrap();
             participants.push(p);
             coefficients.push(c);
             dh_secret_keys.push(dh_sk);
@@ -767,9 +768,9 @@ mod test {
 
         for i in 0..n1 {
             let (pi_state, _participant_lists) = Dkg::<_>::bootstrap(
-                &params,
+                params,
                 &dh_secret_keys[i as usize],
-                &participants[i as usize].index.clone(),
+                participants[i as usize].index,
                 &coefficients[i as usize],
                 &participants,
                 rng,
@@ -790,11 +791,11 @@ mod test {
         participants_states_2.push(
             participants_states_1[0]
                 .clone()
-                .to_round_two(p1_my_encrypted_secret_shares, rng)
+                .to_round_two(&p1_my_encrypted_secret_shares, rng)
                 .unwrap(),
         );
 
-        for i in 2..n1 + 1 {
+        for i in 2..=n1 {
             let mut pi_my_encrypted_secret_shares =
                 Vec::<EncryptedSecretShare<Secp256k1Sha256>>::new();
             for j in 0..n1 {
@@ -806,7 +807,7 @@ mod test {
             participants_states_2.push(
                 participants_states_1[(i - 1) as usize]
                     .clone()
-                    .to_round_two(pi_my_encrypted_secret_shares, rng)
+                    .to_round_two(&pi_my_encrypted_secret_shares, rng)
                     .unwrap(),
             );
         }
@@ -815,7 +816,7 @@ mod test {
         let (group_key, p1_sk) = participants_states_2[0].clone().finish().unwrap();
         participants_secret_keys.push(p1_sk);
 
-        for i in 2..n1 + 1 {
+        for i in 2..=n1 {
             let (_, pi_sk) = participants_states_2[(i - 1) as usize]
                 .clone()
                 .finish()
@@ -829,9 +830,9 @@ mod test {
             let mut signers = Vec::<Participant<Secp256k1Sha256>>::new();
             let mut signers_dh_secret_keys = Vec::<DiffieHellmanPrivateKey<Secp256k1Sha256>>::new();
 
-            for i in 1..n2 + 1 {
+            for i in 1..=n2 {
                 let (p, dh_sk) =
-                    Participant::<Secp256k1Sha256>::new_signer(&params, i, rng).unwrap();
+                    Participant::<Secp256k1Sha256>::new_signer(params, i, rng).unwrap();
                 signers.push(p);
                 signers_dh_secret_keys.push(dh_sk);
             }
@@ -850,12 +851,7 @@ mod test {
 
             for i in 0..n1 as usize {
                 let (dealer_for_signers, dealer_encrypted_shares_for_signers, _participant_lists) =
-                    Participant::reshare(
-                        &new_params,
-                        participants_secret_keys[i].clone(),
-                        &signers,
-                        rng,
-                    )?;
+                    Participant::reshare(new_params, &participants_secret_keys[i], &signers, rng)?;
                 dealers.push(dealer_for_signers);
                 dealers_encrypted_secret_shares_for_signers[i] =
                     dealer_encrypted_shares_for_signers;
@@ -864,9 +860,9 @@ mod test {
             for i in 0..n2 as usize {
                 let (signer_state, _participant_lists) =
                     DistributedKeyGeneration::<RoundOne, Secp256k1Sha256>::new(
-                        &params,
+                        params,
                         &signers_dh_secret_keys[i],
-                        &signers[i].index,
+                        signers[i].index,
                         &dealers,
                         rng,
                     )?;
@@ -885,14 +881,14 @@ mod test {
                 signers_states_2.push(
                     signers_states_1[i]
                         .clone()
-                        .to_round_two(signers_encrypted_secret_shares[i].clone(), rng)
+                        .to_round_two(&signers_encrypted_secret_shares[i].clone(), rng)
                         .unwrap(),
                 );
             }
 
             let mut signers_secret_keys = Vec::<IndividualSigningKey<Secp256k1Sha256>>::new();
 
-            for signers_state in signers_states_2.iter() {
+            for signers_state in &signers_states_2 {
                 let (_, pi_sk) = signers_state.clone().finish().unwrap();
                 signers_secret_keys.push(pi_sk);
             }
@@ -920,10 +916,10 @@ mod test {
 
         let mut aggregator = SignatureAggregator::new(params, group_key, &message[..]);
 
-        aggregator.include_signer(1, p1_public_comshares.commitments[0], (&p1_sk).into());
+        aggregator.include_signer(1, p1_public_comshares.commitments[0], &p1_sk.to_public());
 
         let signers = aggregator.get_signers();
-        let message_hash = Secp256k1Sha256::h4(&message[..]).unwrap();
+        let message_hash = Secp256k1Sha256::h4(&message[..]);
 
         let p1_partial = p1_sk
             .sign(
@@ -935,7 +931,7 @@ mod test {
             )
             .unwrap();
 
-        aggregator.include_partial_signature(p1_partial);
+        aggregator.include_partial_signature(&p1_partial);
 
         let aggregator = aggregator.finalize().unwrap();
         let signing_result = aggregator.aggregate();
@@ -961,10 +957,10 @@ mod test {
 
         let mut aggregator = SignatureAggregator::new(params, group_key, &message[..]);
 
-        aggregator.include_signer(1, p1_public_comshares.commitments[0], (&p1_sk).into());
+        aggregator.include_signer(1, p1_public_comshares.commitments[0], &p1_sk.to_public());
 
         let signers = aggregator.get_signers();
-        let message_hash = Secp256k1Sha256::h4(&message[..]).unwrap();
+        let message_hash = Secp256k1Sha256::h4(&message[..]);
 
         let p1_partial = p1_sk
             .sign(
@@ -976,7 +972,7 @@ mod test {
             )
             .unwrap();
 
-        aggregator.include_partial_signature(p1_partial);
+        aggregator.include_partial_signature(&p1_partial);
 
         let aggregator = aggregator.finalize().unwrap();
         let threshold_signature = aggregator.aggregate().unwrap();
@@ -998,10 +994,10 @@ mod test {
 
         let mut aggregator = SignatureAggregator::new(params, group_key, &message[..]);
 
-        aggregator.include_signer(1, p1_public_comshares.commitments[0], (&p1_sk).into());
+        aggregator.include_signer(1, p1_public_comshares.commitments[0], &p1_sk.to_public());
 
         let signers = aggregator.get_signers();
-        let message_hash = Secp256k1Sha256::h4(&message[..]).unwrap();
+        let message_hash = Secp256k1Sha256::h4(&message[..]);
 
         let p1_partial = p1_sk
             .sign(
@@ -1013,7 +1009,7 @@ mod test {
             )
             .unwrap();
 
-        aggregator.include_partial_signature(p1_partial);
+        aggregator.include_partial_signature(&p1_partial);
 
         let aggregator = aggregator.finalize().unwrap();
         let threshold_signature = aggregator.aggregate().unwrap();
@@ -1041,12 +1037,12 @@ mod test {
 
         let mut aggregator = SignatureAggregator::new(params, group_key, &message[..]);
 
-        aggregator.include_signer(1, p1_public_comshares.commitments[0], (&p1_sk).into());
-        aggregator.include_signer(3, p3_public_comshares.commitments[0], (&p3_sk).into());
-        aggregator.include_signer(4, p4_public_comshares.commitments[0], (&p4_sk).into());
+        aggregator.include_signer(1, p1_public_comshares.commitments[0], &p1_sk.to_public());
+        aggregator.include_signer(3, p3_public_comshares.commitments[0], &p3_sk.to_public());
+        aggregator.include_signer(4, p4_public_comshares.commitments[0], &p4_sk.to_public());
 
         let signers = aggregator.get_signers();
-        let message_hash = Secp256k1Sha256::h4(&message[..]).unwrap();
+        let message_hash = Secp256k1Sha256::h4(&message[..]);
 
         let p1_partial = p1_sk
             .sign(
@@ -1076,9 +1072,9 @@ mod test {
             )
             .unwrap();
 
-        aggregator.include_partial_signature(p1_partial);
-        aggregator.include_partial_signature(p3_partial);
-        aggregator.include_partial_signature(p4_partial);
+        aggregator.include_partial_signature(&p1_partial);
+        aggregator.include_partial_signature(&p3_partial);
+        aggregator.include_partial_signature(&p4_partial);
 
         let aggregator = aggregator.finalize().unwrap();
         let threshold_signature = aggregator.aggregate().unwrap();
@@ -1103,11 +1099,11 @@ mod test {
 
         let mut aggregator = SignatureAggregator::new(params, group_key, &message[..]);
 
-        aggregator.include_signer(1, p1_public_comshares.commitments[0], (&p1_sk).into());
-        aggregator.include_signer(2, p2_public_comshares.commitments[0], (&p2_sk).into());
+        aggregator.include_signer(1, p1_public_comshares.commitments[0], &p1_sk.to_public());
+        aggregator.include_signer(2, p2_public_comshares.commitments[0], &p2_sk.to_public());
 
         let signers = aggregator.get_signers();
-        let message_hash = Secp256k1Sha256::h4(&message[..]).unwrap();
+        let message_hash = Secp256k1Sha256::h4(&message[..]);
 
         let p1_partial = p1_sk
             .sign(
@@ -1128,8 +1124,8 @@ mod test {
             )
             .unwrap();
 
-        aggregator.include_partial_signature(p1_partial);
-        aggregator.include_partial_signature(p2_partial);
+        aggregator.include_partial_signature(&p1_partial);
+        aggregator.include_partial_signature(&p2_partial);
 
         let aggregator = aggregator.finalize().unwrap();
         let signing_result = aggregator.aggregate();
@@ -1163,11 +1159,11 @@ mod test {
 
             let mut aggregator = SignatureAggregator::new(params, group_key, &message[..]);
 
-            aggregator.include_signer(1, d1_public_comshares.commitments[0], (&d1_sk).into());
-            aggregator.include_signer(2, d2_public_comshares.commitments[0], (&d2_sk).into());
+            aggregator.include_signer(1, d1_public_comshares.commitments[0], &d1_sk.to_public());
+            aggregator.include_signer(2, d2_public_comshares.commitments[0], &d2_sk.to_public());
 
             let signers = aggregator.get_signers();
-            let message_hash = Secp256k1Sha256::h4(&message[..]).unwrap();
+            let message_hash = Secp256k1Sha256::h4(&message[..]);
 
             let d1_partial = d1_sk
                 .sign(
@@ -1188,8 +1184,8 @@ mod test {
                 )
                 .unwrap();
 
-            aggregator.include_partial_signature(d1_partial);
-            aggregator.include_partial_signature(d2_partial);
+            aggregator.include_partial_signature(&d1_partial);
+            aggregator.include_partial_signature(&d2_partial);
 
             let aggregator = aggregator.finalize().unwrap();
             let signing_result = aggregator.aggregate();
@@ -1209,11 +1205,11 @@ mod test {
 
             let mut aggregator = SignatureAggregator::new(params, group_key, &message[..]);
 
-            aggregator.include_signer(1, s1_public_comshares.commitments[0], (&s1_sk).into());
-            aggregator.include_signer(2, s2_public_comshares.commitments[0], (&s2_sk).into());
+            aggregator.include_signer(1, s1_public_comshares.commitments[0], &s1_sk.to_public());
+            aggregator.include_signer(2, s2_public_comshares.commitments[0], &s2_sk.to_public());
 
             let signers = aggregator.get_signers();
-            let message_hash = Secp256k1Sha256::h4(&message[..]).unwrap();
+            let message_hash = Secp256k1Sha256::h4(&message[..]);
 
             let s1_partial = s1_sk
                 .sign(
@@ -1234,8 +1230,8 @@ mod test {
                 )
                 .unwrap();
 
-            aggregator.include_partial_signature(s1_partial);
-            aggregator.include_partial_signature(s2_partial);
+            aggregator.include_partial_signature(&s1_partial);
+            aggregator.include_partial_signature(&s2_partial);
 
             let aggregator = aggregator.finalize().unwrap();
             let signing_result = aggregator.aggregate();
@@ -1278,11 +1274,11 @@ mod test {
 
             let mut aggregator = SignatureAggregator::new(d_params, group_key, &message[..]);
 
-            aggregator.include_signer(1, d1_public_comshares.commitments[0], (&d1_sk).into());
-            aggregator.include_signer(2, d2_public_comshares.commitments[0], (&d2_sk).into());
+            aggregator.include_signer(1, d1_public_comshares.commitments[0], &d1_sk.to_public());
+            aggregator.include_signer(2, d2_public_comshares.commitments[0], &d2_sk.to_public());
 
             let signers = aggregator.get_signers();
-            let message_hash = Secp256k1Sha256::h4(&message[..]).unwrap();
+            let message_hash = Secp256k1Sha256::h4(&message[..]);
 
             let d1_partial = d1_sk
                 .sign(
@@ -1303,8 +1299,8 @@ mod test {
                 )
                 .unwrap();
 
-            aggregator.include_partial_signature(d1_partial);
-            aggregator.include_partial_signature(d2_partial);
+            aggregator.include_partial_signature(&d1_partial);
+            aggregator.include_partial_signature(&d2_partial);
 
             let aggregator = aggregator.finalize().unwrap();
             let signing_result = aggregator.aggregate();
@@ -1326,12 +1322,12 @@ mod test {
 
             let mut aggregator = SignatureAggregator::new(s_params, group_key, &message[..]);
 
-            aggregator.include_signer(1, s1_public_comshares.commitments[0], (&s1_sk).into());
-            aggregator.include_signer(2, s2_public_comshares.commitments[0], (&s2_sk).into());
-            aggregator.include_signer(3, s3_public_comshares.commitments[0], (&s3_sk).into());
+            aggregator.include_signer(1, s1_public_comshares.commitments[0], &s1_sk.to_public());
+            aggregator.include_signer(2, s2_public_comshares.commitments[0], &s2_sk.to_public());
+            aggregator.include_signer(3, s3_public_comshares.commitments[0], &s3_sk.to_public());
 
             let signers = aggregator.get_signers();
-            let message_hash = Secp256k1Sha256::h4(&message[..]).unwrap();
+            let message_hash = Secp256k1Sha256::h4(&message[..]);
 
             let s1_partial = s1_sk
                 .sign(
@@ -1361,9 +1357,9 @@ mod test {
                 )
                 .unwrap();
 
-            aggregator.include_partial_signature(s1_partial);
-            aggregator.include_partial_signature(s2_partial);
-            aggregator.include_partial_signature(s3_partial);
+            aggregator.include_partial_signature(&s1_partial);
+            aggregator.include_partial_signature(&s2_partial);
+            aggregator.include_partial_signature(&s3_partial);
 
             let aggregator = aggregator.finalize().unwrap();
             let signing_result = aggregator.aggregate();
@@ -1406,9 +1402,9 @@ mod test {
             &message[..],
         );
 
-        aggregator.include_signer(2, p2_public_comshares.commitments[0], (&p2_sk).into());
-        aggregator.include_signer(1, p1_public_comshares.commitments[0], (&p1_sk).into());
-        aggregator.include_signer(2, p2_public_comshares.commitments[0], (&p2_sk).into());
+        aggregator.include_signer(2, p2_public_comshares.commitments[0], &p2_sk.to_public());
+        aggregator.include_signer(1, p1_public_comshares.commitments[0], &p1_sk.to_public());
+        aggregator.include_signer(2, p2_public_comshares.commitments[0], &p2_sk.to_public());
 
         let signers = aggregator.get_signers();
 
@@ -1443,11 +1439,11 @@ mod test {
 
         let mut aggregator = SignatureAggregator::new(params, group_key, &message[..]);
 
-        aggregator.include_signer(1, p1_public_comshares.commitments[0], (&p1_sk).into());
-        aggregator.include_signer(2, p2_public_comshares.commitments[0], (&p2_sk).into());
+        aggregator.include_signer(1, p1_public_comshares.commitments[0], &p1_sk.to_public());
+        aggregator.include_signer(2, p2_public_comshares.commitments[0], &p2_sk.to_public());
 
         let signers = aggregator.get_signers();
-        let message_hash = Secp256k1Sha256::h4(&message[..]).unwrap();
+        let message_hash = Secp256k1Sha256::h4(&message[..]);
 
         let p1_partial = p1_sk
             .sign(
@@ -1490,8 +1486,8 @@ mod test {
 
         // Continue signature
 
-        aggregator.include_partial_signature(p1_partial);
-        aggregator.include_partial_signature(p2_partial);
+        aggregator.include_partial_signature(&p1_partial);
+        aggregator.include_partial_signature(&p2_partial);
 
         let aggregator = aggregator.finalize().unwrap();
         let signing_result = aggregator.aggregate();

--- a/src/sign/signature.rs
+++ b/src/sign/signature.rs
@@ -881,7 +881,7 @@ mod test {
                 signers_states_2.push(
                     signers_states_1[i]
                         .clone()
-                        .to_round_two(&signers_encrypted_secret_shares[i].clone(), rng)
+                        .to_round_two(&signers_encrypted_secret_shares[i], rng)
                         .unwrap(),
                 );
             }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -44,7 +44,7 @@ pub(crate) fn calculate_lagrange_coefficients<C: CipherSuite>(
     all_indices: &[u32],
 ) -> FrostResult<C, Scalar<C>> {
     let mut sorted_indices = all_indices.to_vec();
-    sorted_indices.sort();
+    sorted_indices.sort_unstable();
     sorted_indices.dedup();
     if sorted_indices.len() != all_indices.len() {
         return Err(Error::Custom("Duplicate indices provided".to_string()));
@@ -60,7 +60,7 @@ pub(crate) fn calculate_lagrange_coefficients<C: CipherSuite>(
 
     let my_index_field = Scalar::<C>::from(my_index);
 
-    for j in sorted_indices.into_iter() {
+    for j in sorted_indices {
         if j == my_index {
             continue;
         }
@@ -76,21 +76,18 @@ pub(crate) fn calculate_lagrange_coefficients<C: CipherSuite>(
             .ok_or_else(|| Error::Custom("Duplicate indices provided".to_string()))?)
 }
 
-pub fn hash_to_field<C: CipherSuite>(
-    context_string: &[u8],
-    message_to_hash: &[u8],
-) -> FrostResult<C, Scalar<C>> {
+pub fn hash_to_field<C: CipherSuite>(context_string: &[u8], message_to_hash: &[u8]) -> Scalar<C> {
     let h = <DefaultFieldHasher<C::InnerHasher, { HASH_SEC_PARAM }> as HashToField<Scalar<C>>>::new(
         context_string,
     );
 
-    Ok(h.hash_to_field(message_to_hash, 1)[0])
+    h.hash_to_field(message_to_hash, 1)[0]
 }
 
 pub fn hash_to_array<C: CipherSuite>(
     context_string: &[u8],
     message_to_hash: &[u8],
-) -> FrostResult<C, C::HashOutput> {
+) -> C::HashOutput {
     let mut h = C::InnerHasher::new();
     h.update(context_string);
     h.update(message_to_hash);
@@ -98,7 +95,7 @@ pub fn hash_to_array<C: CipherSuite>(
     let mut output = C::HashOutput::default();
     output.as_mut().copy_from_slice(h.finalize().as_slice());
 
-    Ok(output)
+    output
 }
 
 #[cfg(test)]

--- a/tests/ice_frost.rs
+++ b/tests/ice_frost.rs
@@ -20,32 +20,32 @@ fn signing_and_verification_3_out_of_5() {
     let params = ThresholdParameters::new(5, 3);
     let rng = OsRng;
 
-    let (p1, p1coeffs, p1_dh_sk) = ParticipantDKG::new_dealer(&params, 1, rng).unwrap();
-    let (p2, p2coeffs, p2_dh_sk) = ParticipantDKG::new_dealer(&params, 2, rng).unwrap();
-    let (p3, p3coeffs, p3_dh_sk) = ParticipantDKG::new_dealer(&params, 3, rng).unwrap();
-    let (p4, p4coeffs, p4_dh_sk) = ParticipantDKG::new_dealer(&params, 4, rng).unwrap();
-    let (p5, p5coeffs, p5_dh_sk) = ParticipantDKG::new_dealer(&params, 5, rng).unwrap();
+    let (p1, p1coeffs, p1_dh_sk) = ParticipantDKG::new_dealer(params, 1, rng).unwrap();
+    let (p2, p2coeffs, p2_dh_sk) = ParticipantDKG::new_dealer(params, 2, rng).unwrap();
+    let (p3, p3coeffs, p3_dh_sk) = ParticipantDKG::new_dealer(params, 3, rng).unwrap();
+    let (p4, p4coeffs, p4_dh_sk) = ParticipantDKG::new_dealer(params, 4, rng).unwrap();
+    let (p5, p5coeffs, p5_dh_sk) = ParticipantDKG::new_dealer(params, 5, rng).unwrap();
 
     let participants: Vec<ParticipantDKG> =
         vec![p1.clone(), p2.clone(), p3.clone(), p4.clone(), p5.clone()];
     let (p1_state, _participant_lists) =
-        Dkg::<_>::bootstrap(&params, &p1_dh_sk, &p1.index, &p1coeffs, &participants, rng).unwrap();
+        Dkg::<_>::bootstrap(params, &p1_dh_sk, p1.index, &p1coeffs, &participants, rng).unwrap();
     let p1_their_encrypted_secret_shares = p1_state.their_encrypted_secret_shares().unwrap();
 
     let (p2_state, _participant_lists) =
-        Dkg::<_>::bootstrap(&params, &p2_dh_sk, &p2.index, &p2coeffs, &participants, rng).unwrap();
+        Dkg::<_>::bootstrap(params, &p2_dh_sk, p2.index, &p2coeffs, &participants, rng).unwrap();
     let p2_their_encrypted_secret_shares = p2_state.their_encrypted_secret_shares().unwrap();
 
     let (p3_state, _participant_lists) =
-        Dkg::<_>::bootstrap(&params, &p3_dh_sk, &p3.index, &p3coeffs, &participants, rng).unwrap();
+        Dkg::<_>::bootstrap(params, &p3_dh_sk, p3.index, &p3coeffs, &participants, rng).unwrap();
     let p3_their_encrypted_secret_shares = p3_state.their_encrypted_secret_shares().unwrap();
 
     let (p4_state, _participant_lists) =
-        Dkg::<_>::bootstrap(&params, &p4_dh_sk, &p4.index, &p4coeffs, &participants, rng).unwrap();
+        Dkg::<_>::bootstrap(params, &p4_dh_sk, p4.index, &p4coeffs, &participants, rng).unwrap();
     let p4_their_encrypted_secret_shares = p4_state.their_encrypted_secret_shares().unwrap();
 
     let (p5_state, _participant_lists) =
-        Dkg::<_>::bootstrap(&params, &p5_dh_sk, &p5.index, &p5coeffs, &participants, rng).unwrap();
+        Dkg::<_>::bootstrap(params, &p5_dh_sk, p5.index, &p5coeffs, &participants, rng).unwrap();
     let p5_their_encrypted_secret_shares = p5_state.their_encrypted_secret_shares().unwrap();
 
     let p1_my_encrypted_secret_shares = vec![
@@ -89,19 +89,19 @@ fn signing_and_verification_3_out_of_5() {
     ];
 
     let p1_state = p1_state
-        .to_round_two(p1_my_encrypted_secret_shares, rng)
+        .to_round_two(&p1_my_encrypted_secret_shares, rng)
         .unwrap();
     let p2_state = p2_state
-        .to_round_two(p2_my_encrypted_secret_shares, rng)
+        .to_round_two(&p2_my_encrypted_secret_shares, rng)
         .unwrap();
     let p3_state = p3_state
-        .to_round_two(p3_my_encrypted_secret_shares, rng)
+        .to_round_two(&p3_my_encrypted_secret_shares, rng)
         .unwrap();
     let p4_state = p4_state
-        .to_round_two(p4_my_encrypted_secret_shares, rng)
+        .to_round_two(&p4_my_encrypted_secret_shares, rng)
         .unwrap();
     let p5_state = p5_state
-        .to_round_two(p5_my_encrypted_secret_shares, rng)
+        .to_round_two(&p5_my_encrypted_secret_shares, rng)
         .unwrap();
 
     let (group_key, p1_sk) = p1_state.finish().unwrap();
@@ -120,12 +120,12 @@ fn signing_and_verification_3_out_of_5() {
 
     let mut aggregator = SignatureAggregator::new(params, group_key, &message[..]);
 
-    aggregator.include_signer(1, p1_public_comshares.commitments[0], (&p1_sk).into());
-    aggregator.include_signer(3, p3_public_comshares.commitments[0], (&p3_sk).into());
-    aggregator.include_signer(4, p4_public_comshares.commitments[0], (&p4_sk).into());
+    aggregator.include_signer(1, p1_public_comshares.commitments[0], &p1_sk.to_public());
+    aggregator.include_signer(3, p3_public_comshares.commitments[0], &p3_sk.to_public());
+    aggregator.include_signer(4, p4_public_comshares.commitments[0], &p4_sk.to_public());
 
     let signers = aggregator.get_signers();
-    let message_hash = Secp256k1Sha256::h4(&message[..]).unwrap();
+    let message_hash = Secp256k1Sha256::h4(&message[..]);
 
     let p1_partial = p1_sk
         .sign(
@@ -155,9 +155,9 @@ fn signing_and_verification_3_out_of_5() {
         )
         .unwrap();
 
-    aggregator.include_partial_signature(p1_partial);
-    aggregator.include_partial_signature(p3_partial);
-    aggregator.include_partial_signature(p4_partial);
+    aggregator.include_partial_signature(&p1_partial);
+    aggregator.include_partial_signature(&p3_partial);
+    aggregator.include_partial_signature(&p4_partial);
 
     let aggregator = aggregator.finalize().unwrap();
     let threshold_signature = aggregator.aggregate().unwrap();


### PR DESCRIPTION
# Description

No fundamental changes, only applied meaningful pedantic lints.
Command ran: `cargo +nightly clippy --all-features --all-targets -- -D warnings -D clippy::pedantic -A clippy::uninlined_format_args -A clippy::too_many_lines -A clippy::doc_markdown -A clippy::cast_sign_loss -A clippy::missing_errors_doc -A clippy::missing_panics_doc -A clippy::module_name_repetitions -A clippy::similar_names`

the only remaining one from the above command on this branch being tagged with the `pedantic` label (while it should be `cast_sign_loss`, but anyways) so can't really silence it.

The reason for ignoring those various lints:
- `uninlined_format_args` -> no strong reason, though the formatting suggestion for display looks odd and not common
- `too_many_lines` -> This comes mostly from unit tests. This was partly handled on the signing module by having a dedicated `do_keygen` method, though this could be applied to a wider extent elsewhere. Would also reduce code duplication, perhaps in another PR?
- `doc_markdown` -> too much noise coming from the maths equations (and I applied the relevant lints from this category, cf changes in `lib.rs` for instance)
- `cast_sign_loss` -> complains about panic which cannot happen in our case
- `missing_errors_doc` -> could be actually a meaningful thing to address, though would be impacting a big part of the doc to respect the linter so didn't address it, at least yet
- `missing_panics_doc` -> most panics will be removed in #16, and for the rest we could apply the linter suggestion if/when dealing with `missing_errors_doc`?
- `module_name_repetitions` -> noisy false positives
- `similar_names` -> tried it in some places but still complaining, so just ignored it

Would be happy to have your thoughts on the above, and notably the ones that may be useful to address (at least in prevention) or possibly to enable the pedantic section in the CI later.

## PR Checklist:

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added or updated tests that comprehensively prove my change is effective or that my feature works
