### PR TITLE
Reuse existing method

### DIFF
--- a/src/dkg/secret_share.rs
+++ b/src/dkg/secret_share.rs
@@ -94,15 +94,8 @@ impl<C: CipherSuite> SecretShare<C> {
     ) -> FrostResult<C, ()> {
         let lhs = C::G::generator() * self.polynomial_evaluation;
         let term: Scalar<C> = self.receiver_index.into();
-        let mut rhs: C::G = <C as CipherSuite>::G::zero();
 
-        for (index, com) in commitment.points.iter().rev().enumerate() {
-            rhs += com;
-
-            if index != (commitment.points.len() - 1) {
-                rhs *= term;
-            }
-        }
+        let rhs = commitment.evaluate_hiding(&term);
 
         match lhs.into_affine() == rhs.into_affine() {
             true => Ok(()),


### PR DESCRIPTION
# Description

Just remove code duplication by calling existing `VerifiableSecretSharingCommitment::evaluate_hiding` method instead.


## PR Checklist:

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added or updated tests that comprehensively prove my change is effective or that my feature works
