### PR TITLE
Fixes several edge cases during DKG and do not abort early

### DIFF
--- a/benches/dkg.rs
+++ b/benches/dkg.rs
@@ -97,7 +97,8 @@ fn criterion_benchmark(c: &mut Criterion) {
         participants_states_1[0]
             .clone()
             .to_round_two(p1_my_encrypted_secret_shares.clone(), rng)
-            .unwrap(),
+            .unwrap()
+            .0,
     );
 
     for i in 2..NUMBER_OF_PARTICIPANTS + 1 {
@@ -114,7 +115,8 @@ fn criterion_benchmark(c: &mut Criterion) {
             participants_states_1[(i - 1) as usize]
                 .clone()
                 .to_round_two(pi_my_encrypted_secret_shares, rng)
-                .unwrap(),
+                .unwrap()
+                .0,
         );
     }
 
@@ -134,7 +136,8 @@ fn criterion_benchmark(c: &mut Criterion) {
     let p1_state = participants_states_1[0]
         .clone()
         .to_round_two(p1_my_encrypted_secret_shares.clone(), rng)
-        .unwrap();
+        .unwrap()
+        .0;
 
     c.bench_function("Finish", move |b| {
         b.iter(|| p1_state.clone().finish());

--- a/benches/dkg.rs
+++ b/benches/dkg.rs
@@ -3,6 +3,8 @@
 #[macro_use]
 extern crate criterion;
 
+use std::collections::BTreeMap;
+
 use criterion::Criterion;
 
 use rand::rngs::OsRng;
@@ -43,10 +45,11 @@ fn criterion_benchmark(c: &mut Criterion) {
         dh_secret_keys.push(dh_sk);
     }
 
-    let mut participants_encrypted_secret_shares: Vec<Vec<EncryptedSecretShare<Secp256k1Sha256>>> =
-        (0..NUMBER_OF_PARTICIPANTS)
-            .map(|_| Vec::with_capacity(NUMBER_OF_PARTICIPANTS as usize))
-            .collect();
+    let mut participants_encrypted_secret_shares: Vec<
+        BTreeMap<u32, EncryptedSecretShare<Secp256k1Sha256>>,
+    > = (0..NUMBER_OF_PARTICIPANTS)
+        .map(|_| BTreeMap::new())
+        .collect();
 
     let mut participants_states_1 = Vec::<Dkg<_>>::with_capacity(NUMBER_OF_PARTICIPANTS as usize);
     let mut participants_states_2 = Vec::<Dkg<_>>::with_capacity(NUMBER_OF_PARTICIPANTS as usize);
@@ -90,8 +93,12 @@ fn criterion_benchmark(c: &mut Criterion) {
             NUMBER_OF_PARTICIPANTS as usize,
         );
     for j in 0..NUMBER_OF_PARTICIPANTS {
-        p1_my_encrypted_secret_shares
-            .push(participants_encrypted_secret_shares[j as usize][0].clone());
+        p1_my_encrypted_secret_shares.push(
+            participants_encrypted_secret_shares[j as usize]
+                .get(&1)
+                .unwrap()
+                .clone(),
+        );
     }
     participants_states_2.push(
         participants_states_1[0]
@@ -107,8 +114,12 @@ fn criterion_benchmark(c: &mut Criterion) {
                 NUMBER_OF_PARTICIPANTS as usize,
             );
         for j in 0..NUMBER_OF_PARTICIPANTS {
-            pi_my_encrypted_secret_shares
-                .push(participants_encrypted_secret_shares[j as usize][(i - 1) as usize].clone());
+            pi_my_encrypted_secret_shares.push(
+                participants_encrypted_secret_shares[j as usize]
+                    .get(&i)
+                    .unwrap()
+                    .clone(),
+            );
         }
 
         participants_states_2.push(

--- a/benches/sign.rs
+++ b/benches/sign.rs
@@ -79,7 +79,8 @@ fn criterion_benchmark(c: &mut Criterion) {
         participants_states_1[0]
             .clone()
             .to_round_two(p1_my_encrypted_secret_shares, rng)
-            .unwrap(),
+            .unwrap()
+            .0,
     );
 
     for i in 2..NUMBER_OF_PARTICIPANTS + 1 {
@@ -96,7 +97,8 @@ fn criterion_benchmark(c: &mut Criterion) {
             participants_states_1[(i - 1) as usize]
                 .clone()
                 .to_round_two(pi_my_encrypted_secret_shares, rng)
-                .unwrap(),
+                .unwrap()
+                .0,
         );
     }
 

--- a/benches/sign.rs
+++ b/benches/sign.rs
@@ -3,6 +3,8 @@
 #[macro_use]
 extern crate criterion;
 
+use std::collections::BTreeMap;
+
 use criterion::Criterion;
 
 use rand::rngs::OsRng;
@@ -44,10 +46,11 @@ fn criterion_benchmark(c: &mut Criterion) {
         dh_secret_keys.push(dh_sk);
     }
 
-    let mut participants_encrypted_secret_shares: Vec<Vec<EncryptedSecretShare<Secp256k1Sha256>>> =
-        (0..NUMBER_OF_PARTICIPANTS)
-            .map(|_| Vec::with_capacity((NUMBER_OF_PARTICIPANTS - 1) as usize))
-            .collect();
+    let mut participants_encrypted_secret_shares: Vec<
+        BTreeMap<u32, EncryptedSecretShare<Secp256k1Sha256>>,
+    > = (0..NUMBER_OF_PARTICIPANTS)
+        .map(|_| BTreeMap::new())
+        .collect();
 
     let mut participants_states_1 = Vec::<Dkg<_>>::with_capacity(NUMBER_OF_PARTICIPANTS as usize);
     let mut participants_states_2 = Vec::<Dkg<_>>::with_capacity(NUMBER_OF_PARTICIPANTS as usize);
@@ -72,8 +75,12 @@ fn criterion_benchmark(c: &mut Criterion) {
             NUMBER_OF_PARTICIPANTS as usize,
         );
     for j in 0..NUMBER_OF_PARTICIPANTS {
-        p1_my_encrypted_secret_shares
-            .push(participants_encrypted_secret_shares[j as usize][0].clone());
+        p1_my_encrypted_secret_shares.push(
+            participants_encrypted_secret_shares[j as usize]
+                .get(&1)
+                .unwrap()
+                .clone(),
+        );
     }
     participants_states_2.push(
         participants_states_1[0]
@@ -89,8 +96,12 @@ fn criterion_benchmark(c: &mut Criterion) {
                 NUMBER_OF_PARTICIPANTS as usize,
             );
         for j in 0..NUMBER_OF_PARTICIPANTS {
-            pi_my_encrypted_secret_shares
-                .push(participants_encrypted_secret_shares[j as usize][(i - 1) as usize].clone());
+            pi_my_encrypted_secret_shares.push(
+                participants_encrypted_secret_shares[j as usize]
+                    .get(&i)
+                    .unwrap()
+                    .clone(),
+            );
         }
 
         participants_states_2.push(

--- a/src/dkg/key_generation.rs
+++ b/src/dkg/key_generation.rs
@@ -99,9 +99,9 @@
 //!
 //! // Alice then collects the secret shares which they send to the other participants:
 //! let alice_their_encrypted_secret_shares = alice_state.their_encrypted_secret_shares()?;
-//! // keep_to_self(alice_their_encrypted_secret_shares[0]);
-//! // send_to_bob(alice_their_encrypted_secret_shares[1]);
-//! // send_to_carol(alice_their_encrypted_secret_shares[2]);
+//! // keep_to_self(alice_their_encrypted_secret_shares.get(&alice.index).unwrap());
+//! // send_to_bob(alice_their_encrypted_secret_shares.get(&bob.index).unwrap());
+//! // send_to_carol(alice_their_encrypted_secret_shares.get(&carol.index).unwrap());
 //!
 //! // Bob enters round one of the distributed key generation protocol.
 //! let (bob_state, participant_lists) =
@@ -117,9 +117,9 @@
 //!
 //! // Bob then collects the secret shares which they send to the other participants:
 //! let bob_their_encrypted_secret_shares = bob_state.their_encrypted_secret_shares()?;
-//! // send_to_alice(bob_their_encrypted_secret_shares[0]);
-//! // keep_to_self(bob_their_encrypted_secret_shares[1]);
-//! // send_to_carol(bob_their_encrypted_secret_shares[2]);
+//! // send_to_alice(bob_their_encrypted_secret_shares.get(&alice.index).unwrap());
+//! // keep_to_self(bob_their_encrypted_secret_shares.get(&bob.index).unwrap());
+//! // send_to_carol(bob_their_encrypted_secret_shares.get(&carol.index).unwrap());
 //!
 //! // Carol enters round one of the distributed key generation protocol.
 //! let (carol_state, participant_lists) =
@@ -135,25 +135,25 @@
 //!
 //! // Carol then collects the secret shares which they send to the other participants:
 //! let carol_their_encrypted_secret_shares = carol_state.their_encrypted_secret_shares()?;
-//! // send_to_alice(carol_their_encrypted_secret_shares[0]);
-//! // send_to_bob(carol_their_encrypted_secret_shares[1]);
-//! // keep_to_self(carol_their_encrypted_secret_shares[2]);
+//! // send_to_alice(carol_their_encrypted_secret_shares.get(&alice.index).unwrap());
+//! // send_to_bob(carol_their_encrypted_secret_shares.get(&bob.index).unwrap());
+//! // keep_to_self(carol_their_encrypted_secret_shares.get(&carol.index).unwrap());
 //!
 //! // Each participant now has a vector of secret shares given to them by the other participants:
 //! let alice_my_encrypted_secret_shares = vec![
-//!     alice_their_encrypted_secret_shares[0].clone(),
-//!     bob_their_encrypted_secret_shares[0].clone(),
-//!     carol_their_encrypted_secret_shares[0].clone(),
+//!     alice_their_encrypted_secret_shares.get(&alice.index).unwrap().clone(),
+//!     bob_their_encrypted_secret_shares.get(&alice.index).unwrap().clone(),
+//!     carol_their_encrypted_secret_shares.get(&alice.index).unwrap().clone(),
 //! ];
 //! let bob_my_encrypted_secret_shares = vec![
-//!     alice_their_encrypted_secret_shares[1].clone(),
-//!     bob_their_encrypted_secret_shares[1].clone(),
-//!     carol_their_encrypted_secret_shares[1].clone(),
+//!     alice_their_encrypted_secret_shares.get(&bob.index).unwrap().clone(),
+//!     bob_their_encrypted_secret_shares.get(&bob.index).unwrap().clone(),
+//!     carol_their_encrypted_secret_shares.get(&bob.index).unwrap().clone(),
 //! ];
 //! let carol_my_encrypted_secret_shares = vec![
-//!     alice_their_encrypted_secret_shares[2].clone(),
-//!     bob_their_encrypted_secret_shares[2].clone(),
-//!     carol_their_encrypted_secret_shares[2].clone(),
+//!     alice_their_encrypted_secret_shares.get(&carol.index).unwrap().clone(),
+//!     bob_their_encrypted_secret_shares.get(&carol.index).unwrap().clone(),
+//!     carol_their_encrypted_secret_shares.get(&carol.index).unwrap().clone(),
 //! ];
 //!
 //! // The participants then use these secret shares from the other participants to advance to
@@ -241,9 +241,9 @@
 //!
 //! // Alice then collects the secret shares which they send to the other participants:
 //! let alice_their_encrypted_secret_shares = alice_state.their_encrypted_secret_shares()?;
-//! // keep_to_self(alice_their_encrypted_secret_shares[0]);
-//! // send_to_bob(alice_their_encrypted_secret_shares[1]);
-//! // send_to_carol(alice_their_encrypted_secret_shares[2]);
+//! // keep_to_self(alice_their_encrypted_secret_shares.get(&alice.index).unwrap());
+//! // send_to_bob(alice_their_encrypted_secret_shares.get(&bob.index).unwrap());
+//! // send_to_carol(alice_their_encrypted_secret_shares.get(&carol.index).unwrap());
 //!
 //! // Bob enters round one of the distributed key generation protocol.
 //! let (bob_state, participant_lists) =
@@ -259,9 +259,9 @@
 //!
 //! // Bob then collects the secret shares which they send to the other participants:
 //! let bob_their_encrypted_secret_shares = bob_state.their_encrypted_secret_shares()?;
-//! // send_to_alice(bob_their_encrypted_secret_shares[0]);
-//! // keep_to_self(bob_their_encrypted_secret_shares[1]);
-//! // send_to_carol(bob_their_encrypted_secret_shares[2]);
+//! // send_to_alice(bob_their_encrypted_secret_shares.get(&alice.index).unwrap());
+//! // keep_to_self(bob_their_encrypted_secret_shares.get(&bob.index).unwrap());
+//! // send_to_carol(bob_their_encrypted_secret_shares.get(&carol.index).unwrap());
 //!
 //! // Carol enters round one of the distributed key generation protocol.
 //! let (carol_state, participant_lists) =
@@ -277,25 +277,25 @@
 //!
 //! // Carol then collects the secret shares which they send to the other participants:
 //! let carol_their_encrypted_secret_shares = carol_state.their_encrypted_secret_shares()?;
-//! // send_to_alice(carol_their_encrypted_secret_shares[0]);
-//! // send_to_bob(carol_their_encrypted_secret_shares[1]);
-//! // keep_to_self(carol_their_encrypted_secret_shares[2]);
+//! // send_to_alice(carol_their_encrypted_secret_shares.get(&alice.index).unwrap());
+//! // send_to_bob(carol_their_encrypted_secret_shares.get(&bob.index).unwrap());
+//! // keep_to_self(carol_their_encrypted_secret_shares.get(&carol.index).unwrap());
 //!
 //! // Each participant now has a vector of secret shares given to them by the other participants:
 //! let alice_my_encrypted_secret_shares = vec![
-//!     alice_their_encrypted_secret_shares[0].clone(),
-//!     bob_their_encrypted_secret_shares[0].clone(),
-//!     carol_their_encrypted_secret_shares[0].clone(),
+//!     alice_their_encrypted_secret_shares.get(&alice.index).unwrap().clone(),
+//!     bob_their_encrypted_secret_shares.get(&alice.index).unwrap().clone(),
+//!     carol_their_encrypted_secret_shares.get(&alice.index).unwrap().clone(),
 //! ];
 //! let bob_my_encrypted_secret_shares = vec![
-//!     alice_their_encrypted_secret_shares[1].clone(),
-//!     bob_their_encrypted_secret_shares[1].clone(),
-//!     carol_their_encrypted_secret_shares[1].clone(),
+//!     alice_their_encrypted_secret_shares.get(&bob.index).unwrap().clone(),
+//!     bob_their_encrypted_secret_shares.get(&bob.index).unwrap().clone(),
+//!     carol_their_encrypted_secret_shares.get(&bob.index).unwrap().clone(),
 //! ];
 //! let carol_my_encrypted_secret_shares = vec![
-//!     alice_their_encrypted_secret_shares[2].clone(),
-//!     bob_their_encrypted_secret_shares[2].clone(),
-//!     carol_their_encrypted_secret_shares[2].clone(),
+//!     alice_their_encrypted_secret_shares.get(&carol.index).unwrap().clone(),
+//!     bob_their_encrypted_secret_shares.get(&carol.index).unwrap().clone(),
+//!     carol_their_encrypted_secret_shares.get(&carol.index).unwrap().clone(),
 //! ];
 //!
 //! // The participants then use these secret shares from the other participants to advance to
@@ -432,24 +432,24 @@
 //! //       set `params` to a 201-out-of-263 setting.
 //!
 //! let alexis_my_encrypted_secret_shares = vec![
-//!     alice_encrypted_shares[0].clone(),
-//!     bob_encrypted_shares[0].clone(),
-//!     carol_encrypted_shares[0].clone(),
+//!     alice_encrypted_shares.get(&alexis.index).unwrap().clone(),
+//!     bob_encrypted_shares.get(&alexis.index).unwrap().clone(),
+//!     carol_encrypted_shares.get(&alexis.index).unwrap().clone(),
 //! ];
 //! let barbara_my_encrypted_secret_shares = vec![
-//!     alice_encrypted_shares[1].clone(),
-//!     bob_encrypted_shares[1].clone(),
-//!     carol_encrypted_shares[1].clone()
+//!     alice_encrypted_shares.get(&barbara.index).unwrap().clone(),
+//!     bob_encrypted_shares.get(&barbara.index).unwrap().clone(),
+//!     carol_encrypted_shares.get(&barbara.index).unwrap().clone()
 //! ];
 //! let claire_my_encrypted_secret_shares = vec![
-//!     alice_encrypted_shares[2].clone(),
-//!     bob_encrypted_shares[2].clone(),
-//!     carol_encrypted_shares[2].clone()
+//!     alice_encrypted_shares.get(&claire.index).unwrap().clone(),
+//!     bob_encrypted_shares.get(&claire.index).unwrap().clone(),
+//!     carol_encrypted_shares.get(&claire.index).unwrap().clone()
 //! ];
 //! let david_my_encrypted_secret_shares = vec![
-//!     alice_encrypted_shares[3].clone(),
-//!     bob_encrypted_shares[3].clone(),
-//!     carol_encrypted_shares[3].clone()
+//!     alice_encrypted_shares.get(&david.index).unwrap().clone(),
+//!     bob_encrypted_shares.get(&david.index).unwrap().clone(),
+//!     carol_encrypted_shares.get(&david.index).unwrap().clone()
 //! ];
 //!
 //! // Alexis, Barbara, Claire and David can now finish the resharing DKG with the received
@@ -546,7 +546,7 @@ struct ActualState<C: CipherSuite> {
     /// respective participant's DH public key.
     their_dh_public_keys: BTreeMap<u32, DiffieHellmanPublicKey<C>>,
     /// The encrypted secret shares this participant has calculated for all the other participants.
-    their_encrypted_secret_shares: Option<Vec<EncryptedSecretShare<C>>>,
+    their_encrypted_secret_shares: Option<BTreeMap<u32, EncryptedSecretShare<C>>>,
     /// The secret shares this participant has received from all the other participants.
     my_secret_shares: Option<BTreeMap<u32, SecretShare<C>>>,
 }
@@ -801,8 +801,8 @@ impl<C: CipherSuite> DistributedKeyGeneration<RoundOne, C> {
         // Round 2
         // Step 1: Each P_i securely sends to each other participant P_l a secret share
         //         (l, f_i(l)) and keeps (i, f_i(i)) for themselves.
-        let mut their_encrypted_secret_shares: Vec<EncryptedSecretShare<C>> =
-            Vec::with_capacity(parameters.n as usize - 1);
+        let mut their_encrypted_secret_shares: BTreeMap<u32, EncryptedSecretShare<C>> =
+            BTreeMap::new();
 
         for p in participants.iter() {
             let share =
@@ -814,7 +814,8 @@ impl<C: CipherSuite> DistributedKeyGeneration<RoundOne, C> {
                 .serialize_compressed(&mut dh_key_bytes)
                 .map_err(|_| Error::CompressionError)?;
 
-            their_encrypted_secret_shares.push(encrypt_share(&share, &dh_key_bytes[..], &mut rng)?);
+            their_encrypted_secret_shares
+                .insert(p.index, encrypt_share(&share, &dh_key_bytes[..], &mut rng)?);
         }
 
         let state = ActualState {
@@ -850,7 +851,9 @@ impl<C: CipherSuite> DistributedKeyGeneration<RoundOne, C> {
 
     /// Retrieve an encrypted secret share for each other participant, to be given to them
     /// at the end of [`DistributedKeyGeneration::<RoundOne, C>`] .
-    pub fn their_encrypted_secret_shares(&self) -> FrostResult<C, &Vec<EncryptedSecretShare<C>>> {
+    pub fn their_encrypted_secret_shares(
+        &self,
+    ) -> FrostResult<C, &BTreeMap<u32, EncryptedSecretShare<C>>> {
         self.state
             .their_encrypted_secret_shares
             .as_ref()
@@ -1234,10 +1237,14 @@ mod test {
                 rng,
             )
             .unwrap();
-        let p1_my_encrypted_secret_shares =
-            p1_state.their_encrypted_secret_shares().unwrap().clone();
+        let p1_my_encrypted_secret_shares = p1_state
+            .their_encrypted_secret_shares()
+            .unwrap()
+            .get(&1)
+            .unwrap()
+            .clone();
         let (p1_state, complaints) = p1_state
-            .to_round_two(p1_my_encrypted_secret_shares, rng)
+            .to_round_two(vec![p1_my_encrypted_secret_shares], rng)
             .unwrap();
         assert!(complaints.is_empty());
         let result = p1_state.finish();
@@ -1354,43 +1361,43 @@ mod test {
         let p5_their_encrypted_secret_shares = p5_state.their_encrypted_secret_shares().unwrap();
 
         let p1_my_encrypted_secret_shares = vec![
-            p1_their_encrypted_secret_shares[0].clone(),
-            p2_their_encrypted_secret_shares[0].clone(),
-            p3_their_encrypted_secret_shares[0].clone(),
-            p4_their_encrypted_secret_shares[0].clone(),
-            p5_their_encrypted_secret_shares[0].clone(),
+            p1_their_encrypted_secret_shares.get(&1).unwrap().clone(),
+            p2_their_encrypted_secret_shares.get(&1).unwrap().clone(),
+            p3_their_encrypted_secret_shares.get(&1).unwrap().clone(),
+            p4_their_encrypted_secret_shares.get(&1).unwrap().clone(),
+            p5_their_encrypted_secret_shares.get(&1).unwrap().clone(),
         ];
 
         let p2_my_encrypted_secret_shares = vec![
-            p1_their_encrypted_secret_shares[1].clone(),
-            p2_their_encrypted_secret_shares[1].clone(),
-            p3_their_encrypted_secret_shares[1].clone(),
-            p4_their_encrypted_secret_shares[1].clone(),
-            p5_their_encrypted_secret_shares[1].clone(),
+            p1_their_encrypted_secret_shares.get(&2).unwrap().clone(),
+            p2_their_encrypted_secret_shares.get(&2).unwrap().clone(),
+            p3_their_encrypted_secret_shares.get(&2).unwrap().clone(),
+            p4_their_encrypted_secret_shares.get(&2).unwrap().clone(),
+            p5_their_encrypted_secret_shares.get(&2).unwrap().clone(),
         ];
 
         let p3_my_encrypted_secret_shares = vec![
-            p1_their_encrypted_secret_shares[2].clone(),
-            p2_their_encrypted_secret_shares[2].clone(),
-            p3_their_encrypted_secret_shares[2].clone(),
-            p4_their_encrypted_secret_shares[2].clone(),
-            p5_their_encrypted_secret_shares[2].clone(),
+            p1_their_encrypted_secret_shares.get(&3).unwrap().clone(),
+            p2_their_encrypted_secret_shares.get(&3).unwrap().clone(),
+            p3_their_encrypted_secret_shares.get(&3).unwrap().clone(),
+            p4_their_encrypted_secret_shares.get(&3).unwrap().clone(),
+            p5_their_encrypted_secret_shares.get(&3).unwrap().clone(),
         ];
 
         let p4_my_encrypted_secret_shares = vec![
-            p1_their_encrypted_secret_shares[3].clone(),
-            p2_their_encrypted_secret_shares[3].clone(),
-            p3_their_encrypted_secret_shares[3].clone(),
-            p4_their_encrypted_secret_shares[3].clone(),
-            p5_their_encrypted_secret_shares[3].clone(),
+            p1_their_encrypted_secret_shares.get(&4).unwrap().clone(),
+            p2_their_encrypted_secret_shares.get(&4).unwrap().clone(),
+            p3_their_encrypted_secret_shares.get(&4).unwrap().clone(),
+            p4_their_encrypted_secret_shares.get(&4).unwrap().clone(),
+            p5_their_encrypted_secret_shares.get(&4).unwrap().clone(),
         ];
 
         let p5_my_encrypted_secret_shares = vec![
-            p1_their_encrypted_secret_shares[4].clone(),
-            p2_their_encrypted_secret_shares[4].clone(),
-            p3_their_encrypted_secret_shares[4].clone(),
-            p4_their_encrypted_secret_shares[4].clone(),
-            p5_their_encrypted_secret_shares[4].clone(),
+            p1_their_encrypted_secret_shares.get(&5).unwrap().clone(),
+            p2_their_encrypted_secret_shares.get(&5).unwrap().clone(),
+            p3_their_encrypted_secret_shares.get(&5).unwrap().clone(),
+            p4_their_encrypted_secret_shares.get(&5).unwrap().clone(),
+            p5_their_encrypted_secret_shares.get(&5).unwrap().clone(),
         ];
 
         let (p1_state, complaints) = p1_state
@@ -1511,19 +1518,19 @@ mod test {
             let p3_their_encrypted_secret_shares = p3_state.their_encrypted_secret_shares()?;
 
             let p1_my_encrypted_secret_shares = vec![
-                p1_their_encrypted_secret_shares[0].clone(),
-                p2_their_encrypted_secret_shares[0].clone(),
-                p3_their_encrypted_secret_shares[0].clone(),
+                p1_their_encrypted_secret_shares.get(&1).unwrap().clone(),
+                p2_their_encrypted_secret_shares.get(&1).unwrap().clone(),
+                p3_their_encrypted_secret_shares.get(&1).unwrap().clone(),
             ];
             let p2_my_encrypted_secret_shares = vec![
-                p1_their_encrypted_secret_shares[1].clone(),
-                p2_their_encrypted_secret_shares[1].clone(),
-                p3_their_encrypted_secret_shares[1].clone(),
+                p1_their_encrypted_secret_shares.get(&2).unwrap().clone(),
+                p2_their_encrypted_secret_shares.get(&2).unwrap().clone(),
+                p3_their_encrypted_secret_shares.get(&2).unwrap().clone(),
             ];
             let p3_my_encrypted_secret_shares = vec![
-                p1_their_encrypted_secret_shares[2].clone(),
-                p2_their_encrypted_secret_shares[2].clone(),
-                p3_their_encrypted_secret_shares[2].clone(),
+                p1_their_encrypted_secret_shares.get(&3).unwrap().clone(),
+                p2_their_encrypted_secret_shares.get(&3).unwrap().clone(),
+                p3_their_encrypted_secret_shares.get(&3).unwrap().clone(),
             ];
 
             let (p1_state, complaints) =
@@ -1616,19 +1623,46 @@ mod test {
                 dealer3_state.their_encrypted_secret_shares()?;
 
             let dealer1_my_encrypted_secret_shares = vec![
-                dealer1_their_encrypted_secret_shares[0].clone(),
-                dealer2_their_encrypted_secret_shares[0].clone(),
-                dealer3_their_encrypted_secret_shares[0].clone(),
+                dealer1_their_encrypted_secret_shares
+                    .get(&1)
+                    .unwrap()
+                    .clone(),
+                dealer2_their_encrypted_secret_shares
+                    .get(&1)
+                    .unwrap()
+                    .clone(),
+                dealer3_their_encrypted_secret_shares
+                    .get(&1)
+                    .unwrap()
+                    .clone(),
             ];
             let dealer2_my_encrypted_secret_shares = vec![
-                dealer1_their_encrypted_secret_shares[1].clone(),
-                dealer2_their_encrypted_secret_shares[1].clone(),
-                dealer3_their_encrypted_secret_shares[1].clone(),
+                dealer1_their_encrypted_secret_shares
+                    .get(&2)
+                    .unwrap()
+                    .clone(),
+                dealer2_their_encrypted_secret_shares
+                    .get(&2)
+                    .unwrap()
+                    .clone(),
+                dealer3_their_encrypted_secret_shares
+                    .get(&2)
+                    .unwrap()
+                    .clone(),
             ];
             let dealer3_my_encrypted_secret_shares = vec![
-                dealer1_their_encrypted_secret_shares[2].clone(),
-                dealer2_their_encrypted_secret_shares[2].clone(),
-                dealer3_their_encrypted_secret_shares[2].clone(),
+                dealer1_their_encrypted_secret_shares
+                    .get(&3)
+                    .unwrap()
+                    .clone(),
+                dealer2_their_encrypted_secret_shares
+                    .get(&3)
+                    .unwrap()
+                    .clone(),
+                dealer3_their_encrypted_secret_shares
+                    .get(&3)
+                    .unwrap()
+                    .clone(),
             ];
 
             let (dealer1_state, complaints) =
@@ -1696,19 +1730,46 @@ mod test {
                 )?;
 
             let signer1_my_encrypted_secret_shares = vec![
-                dealer1_encrypted_shares_for_signers[0].clone(),
-                dealer2_encrypted_shares_for_signers[0].clone(),
-                dealer3_encrypted_shares_for_signers[0].clone(),
+                dealer1_encrypted_shares_for_signers
+                    .get(&1)
+                    .unwrap()
+                    .clone(),
+                dealer2_encrypted_shares_for_signers
+                    .get(&1)
+                    .unwrap()
+                    .clone(),
+                dealer3_encrypted_shares_for_signers
+                    .get(&1)
+                    .unwrap()
+                    .clone(),
             ];
             let signer2_my_encrypted_secret_shares = vec![
-                dealer1_encrypted_shares_for_signers[1].clone(),
-                dealer2_encrypted_shares_for_signers[1].clone(),
-                dealer3_encrypted_shares_for_signers[1].clone(),
+                dealer1_encrypted_shares_for_signers
+                    .get(&2)
+                    .unwrap()
+                    .clone(),
+                dealer2_encrypted_shares_for_signers
+                    .get(&2)
+                    .unwrap()
+                    .clone(),
+                dealer3_encrypted_shares_for_signers
+                    .get(&2)
+                    .unwrap()
+                    .clone(),
             ];
             let signer3_my_encrypted_secret_shares = vec![
-                dealer1_encrypted_shares_for_signers[2].clone(),
-                dealer2_encrypted_shares_for_signers[2].clone(),
-                dealer3_encrypted_shares_for_signers[2].clone(),
+                dealer1_encrypted_shares_for_signers
+                    .get(&3)
+                    .unwrap()
+                    .clone(),
+                dealer2_encrypted_shares_for_signers
+                    .get(&3)
+                    .unwrap()
+                    .clone(),
+                dealer3_encrypted_shares_for_signers
+                    .get(&3)
+                    .unwrap()
+                    .clone(),
             ];
 
             let (signer1_state, complaints) =
@@ -1803,19 +1864,46 @@ mod test {
                 dealer3_state.their_encrypted_secret_shares()?;
 
             let dealer1_my_encrypted_secret_shares = vec![
-                dealer1_their_encrypted_secret_shares[0].clone(),
-                dealer2_their_encrypted_secret_shares[0].clone(),
-                dealer3_their_encrypted_secret_shares[0].clone(),
+                dealer1_their_encrypted_secret_shares
+                    .get(&1)
+                    .unwrap()
+                    .clone(),
+                dealer2_their_encrypted_secret_shares
+                    .get(&1)
+                    .unwrap()
+                    .clone(),
+                dealer3_their_encrypted_secret_shares
+                    .get(&1)
+                    .unwrap()
+                    .clone(),
             ];
             let dealer2_my_encrypted_secret_shares = vec![
-                dealer1_their_encrypted_secret_shares[1].clone(),
-                dealer2_their_encrypted_secret_shares[1].clone(),
-                dealer3_their_encrypted_secret_shares[1].clone(),
+                dealer1_their_encrypted_secret_shares
+                    .get(&2)
+                    .unwrap()
+                    .clone(),
+                dealer2_their_encrypted_secret_shares
+                    .get(&2)
+                    .unwrap()
+                    .clone(),
+                dealer3_their_encrypted_secret_shares
+                    .get(&2)
+                    .unwrap()
+                    .clone(),
             ];
             let dealer3_my_encrypted_secret_shares = vec![
-                dealer1_their_encrypted_secret_shares[2].clone(),
-                dealer2_their_encrypted_secret_shares[2].clone(),
-                dealer3_their_encrypted_secret_shares[2].clone(),
+                dealer1_their_encrypted_secret_shares
+                    .get(&3)
+                    .unwrap()
+                    .clone(),
+                dealer2_their_encrypted_secret_shares
+                    .get(&3)
+                    .unwrap()
+                    .clone(),
+                dealer3_their_encrypted_secret_shares
+                    .get(&3)
+                    .unwrap()
+                    .clone(),
             ];
 
             let (dealer1_state, complaints) =
@@ -1913,29 +2001,74 @@ mod test {
                 )?;
 
             let signer1_my_encrypted_secret_shares = vec![
-                dealer1_encrypted_shares_for_signers[0].clone(),
-                dealer2_encrypted_shares_for_signers[0].clone(),
-                dealer3_encrypted_shares_for_signers[0].clone(),
+                dealer1_encrypted_shares_for_signers
+                    .get(&1)
+                    .unwrap()
+                    .clone(),
+                dealer2_encrypted_shares_for_signers
+                    .get(&1)
+                    .unwrap()
+                    .clone(),
+                dealer3_encrypted_shares_for_signers
+                    .get(&1)
+                    .unwrap()
+                    .clone(),
             ];
             let signer2_my_encrypted_secret_shares = vec![
-                dealer1_encrypted_shares_for_signers[1].clone(),
-                dealer2_encrypted_shares_for_signers[1].clone(),
-                dealer3_encrypted_shares_for_signers[1].clone(),
+                dealer1_encrypted_shares_for_signers
+                    .get(&2)
+                    .unwrap()
+                    .clone(),
+                dealer2_encrypted_shares_for_signers
+                    .get(&2)
+                    .unwrap()
+                    .clone(),
+                dealer3_encrypted_shares_for_signers
+                    .get(&2)
+                    .unwrap()
+                    .clone(),
             ];
             let signer3_my_encrypted_secret_shares = vec![
-                dealer1_encrypted_shares_for_signers[2].clone(),
-                dealer2_encrypted_shares_for_signers[2].clone(),
-                dealer3_encrypted_shares_for_signers[2].clone(),
+                dealer1_encrypted_shares_for_signers
+                    .get(&3)
+                    .unwrap()
+                    .clone(),
+                dealer2_encrypted_shares_for_signers
+                    .get(&3)
+                    .unwrap()
+                    .clone(),
+                dealer3_encrypted_shares_for_signers
+                    .get(&3)
+                    .unwrap()
+                    .clone(),
             ];
             let signer4_my_encrypted_secret_shares = vec![
-                dealer1_encrypted_shares_for_signers[3].clone(),
-                dealer2_encrypted_shares_for_signers[3].clone(),
-                dealer3_encrypted_shares_for_signers[3].clone(),
+                dealer1_encrypted_shares_for_signers
+                    .get(&4)
+                    .unwrap()
+                    .clone(),
+                dealer2_encrypted_shares_for_signers
+                    .get(&4)
+                    .unwrap()
+                    .clone(),
+                dealer3_encrypted_shares_for_signers
+                    .get(&4)
+                    .unwrap()
+                    .clone(),
             ];
             let signer5_my_encrypted_secret_shares = vec![
-                dealer1_encrypted_shares_for_signers[4].clone(),
-                dealer2_encrypted_shares_for_signers[4].clone(),
-                dealer3_encrypted_shares_for_signers[4].clone(),
+                dealer1_encrypted_shares_for_signers
+                    .get(&5)
+                    .unwrap()
+                    .clone(),
+                dealer2_encrypted_shares_for_signers
+                    .get(&5)
+                    .unwrap()
+                    .clone(),
+                dealer3_encrypted_shares_for_signers
+                    .get(&5)
+                    .unwrap()
+                    .clone(),
             ];
 
             let (signer1_state, complaints) =
@@ -2056,19 +2189,19 @@ mod test {
             let p3_their_encrypted_secret_shares = p3_state.their_encrypted_secret_shares()?;
 
             let p1_my_encrypted_secret_shares = vec![
-                p1_their_encrypted_secret_shares[0].clone(),
-                p2_their_encrypted_secret_shares[0].clone(),
-                p3_their_encrypted_secret_shares[0].clone(),
+                p1_their_encrypted_secret_shares.get(&1).unwrap().clone(),
+                p2_their_encrypted_secret_shares.get(&1).unwrap().clone(),
+                p3_their_encrypted_secret_shares.get(&1).unwrap().clone(),
             ];
             let p2_my_encrypted_secret_shares = vec![
-                p1_their_encrypted_secret_shares[1].clone(),
-                p2_their_encrypted_secret_shares[1].clone(),
-                p3_their_encrypted_secret_shares[1].clone(),
+                p1_their_encrypted_secret_shares.get(&2).unwrap().clone(),
+                p2_their_encrypted_secret_shares.get(&2).unwrap().clone(),
+                p3_their_encrypted_secret_shares.get(&2).unwrap().clone(),
             ];
             let p3_my_encrypted_secret_shares = vec![
-                p1_their_encrypted_secret_shares[2].clone(),
-                p2_their_encrypted_secret_shares[2].clone(),
-                p3_their_encrypted_secret_shares[2].clone(),
+                p1_their_encrypted_secret_shares.get(&3).unwrap().clone(),
+                p2_their_encrypted_secret_shares.get(&3).unwrap().clone(),
+                p3_their_encrypted_secret_shares.get(&3).unwrap().clone(),
             ];
 
             let (p1_state, complaints) =
@@ -2158,23 +2291,24 @@ mod test {
 
             // Wrong decryption from nonce
             {
-                let mut wrong_encrypted_secret_share = p1_their_encrypted_secret_shares[1].clone();
+                let mut wrong_encrypted_secret_share =
+                    p1_their_encrypted_secret_shares.get(&2).unwrap().clone();
                 wrong_encrypted_secret_share.nonce = [42; 16];
                 let p1_my_encrypted_secret_shares = vec![
-                    p1_their_encrypted_secret_shares[0].clone(),
-                    p2_their_encrypted_secret_shares[0].clone(),
-                    p3_their_encrypted_secret_shares[0].clone(),
+                    p1_their_encrypted_secret_shares.get(&1).unwrap().clone(),
+                    p2_their_encrypted_secret_shares.get(&1).unwrap().clone(),
+                    p3_their_encrypted_secret_shares.get(&1).unwrap().clone(),
                 ];
                 // Wrong share inserted here!
                 let p2_my_encrypted_secret_shares = vec![
                     wrong_encrypted_secret_share.clone(),
-                    p2_their_encrypted_secret_shares[1].clone(),
-                    p3_their_encrypted_secret_shares[1].clone(),
+                    p2_their_encrypted_secret_shares.get(&2).unwrap().clone(),
+                    p3_their_encrypted_secret_shares.get(&2).unwrap().clone(),
                 ];
                 let p3_my_encrypted_secret_shares = vec![
-                    p1_their_encrypted_secret_shares[2].clone(),
-                    p2_their_encrypted_secret_shares[2].clone(),
-                    p3_their_encrypted_secret_shares[2].clone(),
+                    p1_their_encrypted_secret_shares.get(&3).unwrap().clone(),
+                    p2_their_encrypted_secret_shares.get(&3).unwrap().clone(),
+                    p3_their_encrypted_secret_shares.get(&3).unwrap().clone(),
                 ];
 
                 let (mut p1_state, complaints) = p1_state
@@ -2214,23 +2348,24 @@ mod test {
 
             // Wrong decryption of polynomial evaluation
             {
-                let mut wrong_encrypted_secret_share = p1_their_encrypted_secret_shares[1].clone();
+                let mut wrong_encrypted_secret_share =
+                    p1_their_encrypted_secret_shares.get(&2).unwrap().clone();
                 wrong_encrypted_secret_share.encrypted_polynomial_evaluation = vec![42; 32];
                 let p1_my_encrypted_secret_shares = vec![
-                    p1_their_encrypted_secret_shares[0].clone(),
-                    p2_their_encrypted_secret_shares[0].clone(),
-                    p3_their_encrypted_secret_shares[0].clone(),
+                    p1_their_encrypted_secret_shares.get(&1).unwrap().clone(),
+                    p2_their_encrypted_secret_shares.get(&1).unwrap().clone(),
+                    p3_their_encrypted_secret_shares.get(&1).unwrap().clone(),
                 ];
                 // Wrong share inserted here!
                 let p2_my_encrypted_secret_shares = vec![
                     wrong_encrypted_secret_share.clone(),
-                    p2_their_encrypted_secret_shares[1].clone(),
-                    p3_their_encrypted_secret_shares[1].clone(),
+                    p2_their_encrypted_secret_shares.get(&2).unwrap().clone(),
+                    p3_their_encrypted_secret_shares.get(&2).unwrap().clone(),
                 ];
                 let p3_my_encrypted_secret_shares = vec![
-                    p1_their_encrypted_secret_shares[2].clone(),
-                    p2_their_encrypted_secret_shares[2].clone(),
-                    p3_their_encrypted_secret_shares[2].clone(),
+                    p1_their_encrypted_secret_shares.get(&3).unwrap().clone(),
+                    p2_their_encrypted_secret_shares.get(&3).unwrap().clone(),
+                    p3_their_encrypted_secret_shares.get(&3).unwrap().clone(),
                 ];
 
                 let (mut p1_state, complaints) = p1_state
@@ -2279,20 +2414,20 @@ mod test {
                 )
                 .unwrap();
                 let p1_my_encrypted_secret_shares = vec![
-                    p1_their_encrypted_secret_shares[0].clone(),
-                    p2_their_encrypted_secret_shares[0].clone(),
-                    p3_their_encrypted_secret_shares[0].clone(),
+                    p1_their_encrypted_secret_shares.get(&1).unwrap().clone(),
+                    p2_their_encrypted_secret_shares.get(&1).unwrap().clone(),
+                    p3_their_encrypted_secret_shares.get(&1).unwrap().clone(),
                 ];
                 // Wrong share inserted here!
                 let p2_my_encrypted_secret_shares = vec![
                     wrong_encrypted_secret_share.clone(),
-                    p2_their_encrypted_secret_shares[1].clone(),
-                    p3_their_encrypted_secret_shares[1].clone(),
+                    p2_their_encrypted_secret_shares.get(&2).unwrap().clone(),
+                    p3_their_encrypted_secret_shares.get(&2).unwrap().clone(),
                 ];
                 let p3_my_encrypted_secret_shares = vec![
-                    p1_their_encrypted_secret_shares[2].clone(),
-                    p2_their_encrypted_secret_shares[2].clone(),
-                    p3_their_encrypted_secret_shares[2].clone(),
+                    p1_their_encrypted_secret_shares.get(&3).unwrap().clone(),
+                    p2_their_encrypted_secret_shares.get(&3).unwrap().clone(),
+                    p3_their_encrypted_secret_shares.get(&3).unwrap().clone(),
                 ];
 
                 let (mut p1_state, complaints) = p1_state
@@ -2328,26 +2463,29 @@ mod test {
             // Wrong complaint leads to blaming the complaint maker
             {
                 let _p1_my_encrypted_secret_shares = vec![
-                    p1_their_encrypted_secret_shares[0].clone(),
-                    p2_their_encrypted_secret_shares[0].clone(),
-                    p3_their_encrypted_secret_shares[0].clone(),
+                    p1_their_encrypted_secret_shares.get(&1).unwrap().clone(),
+                    p2_their_encrypted_secret_shares.get(&1).unwrap().clone(),
+                    p3_their_encrypted_secret_shares.get(&1).unwrap().clone(),
                 ];
                 let _p2_my_encrypted_secret_shares = vec![
-                    p1_their_encrypted_secret_shares[0].clone(),
-                    p2_their_encrypted_secret_shares[1].clone(),
-                    p3_their_encrypted_secret_shares[1].clone(),
+                    p1_their_encrypted_secret_shares.get(&1).unwrap().clone(),
+                    p2_their_encrypted_secret_shares.get(&2).unwrap().clone(),
+                    p3_their_encrypted_secret_shares.get(&2).unwrap().clone(),
                 ];
                 let p3_my_encrypted_secret_shares = vec![
-                    p1_their_encrypted_secret_shares[2].clone(),
-                    p2_their_encrypted_secret_shares[2].clone(),
-                    p3_their_encrypted_secret_shares[2].clone(),
+                    p1_their_encrypted_secret_shares.get(&3).unwrap().clone(),
+                    p2_their_encrypted_secret_shares.get(&3).unwrap().clone(),
+                    p3_their_encrypted_secret_shares.get(&3).unwrap().clone(),
                 ];
 
                 let (mut p3_state, _) = p3_state
                     .clone()
                     .to_round_two(p3_my_encrypted_secret_shares, rng)?;
 
-                let bad_index = p3_state.blame(&p1_their_encrypted_secret_shares[0], &complaint);
+                let bad_index = p3_state.blame(
+                    &p1_their_encrypted_secret_shares.get(&1).unwrap().clone(),
+                    &complaint,
+                );
                 assert!(bad_index == 2);
             }
 
@@ -2416,19 +2554,19 @@ mod test {
 
             {
                 let p1_my_encrypted_secret_shares = vec![
-                    p1_their_encrypted_secret_shares[0].clone(),
-                    p2_their_encrypted_secret_shares[0].clone(),
-                    p3_their_encrypted_secret_shares[0].clone(),
+                    p1_their_encrypted_secret_shares.get(&1).unwrap().clone(),
+                    p2_their_encrypted_secret_shares.get(&1).unwrap().clone(),
+                    p3_their_encrypted_secret_shares.get(&1).unwrap().clone(),
                 ];
                 let p2_my_encrypted_secret_shares = vec![
-                    p1_their_encrypted_secret_shares[1].clone(),
-                    p2_their_encrypted_secret_shares[1].clone(),
-                    p3_their_encrypted_secret_shares[1].clone(),
+                    p1_their_encrypted_secret_shares.get(&2).unwrap().clone(),
+                    p2_their_encrypted_secret_shares.get(&2).unwrap().clone(),
+                    p3_their_encrypted_secret_shares.get(&2).unwrap().clone(),
                 ];
                 let p3_my_encrypted_secret_shares = vec![
-                    p1_their_encrypted_secret_shares[2].clone(),
-                    p2_their_encrypted_secret_shares[2].clone(),
-                    p3_their_encrypted_secret_shares[2].clone(),
+                    p1_their_encrypted_secret_shares.get(&3).unwrap().clone(),
+                    p2_their_encrypted_secret_shares.get(&3).unwrap().clone(),
+                    p3_their_encrypted_secret_shares.get(&3).unwrap().clone(),
                 ];
 
                 // Check serialization
@@ -2452,9 +2590,17 @@ mod test {
                     NizkPokOfSecretKey::from_bytes(&bytes)?
                 );
 
-                let bytes = p1_state.their_encrypted_secret_shares()?[0].to_bytes()?;
+                let bytes = p1_state
+                    .their_encrypted_secret_shares()?
+                    .get(&1)
+                    .unwrap()
+                    .to_bytes()?;
                 assert_eq!(
-                    p1_state.their_encrypted_secret_shares()?[0],
+                    p1_state
+                        .their_encrypted_secret_shares()?
+                        .get(&1)
+                        .unwrap()
+                        .clone(),
                     EncryptedSecretShare::from_bytes(&bytes)?
                 );
 
@@ -2504,19 +2650,19 @@ mod test {
                     EncryptedSecretShare::new(1, 2, [0; 16], vec![0]);
 
                 let p1_my_encrypted_secret_shares = vec![
-                    p1_their_encrypted_secret_shares[0].clone(),
-                    p2_their_encrypted_secret_shares[0].clone(),
-                    p3_their_encrypted_secret_shares[0].clone(),
+                    p1_their_encrypted_secret_shares.get(&1).unwrap().clone(),
+                    p2_their_encrypted_secret_shares.get(&1).unwrap().clone(),
+                    p3_their_encrypted_secret_shares.get(&1).unwrap().clone(),
                 ];
                 let p2_my_encrypted_secret_shares = vec![
                     wrong_encrypted_secret_share.clone(),
-                    p2_their_encrypted_secret_shares[1].clone(),
-                    p3_their_encrypted_secret_shares[1].clone(),
+                    p2_their_encrypted_secret_shares.get(&2).unwrap().clone(),
+                    p3_their_encrypted_secret_shares.get(&2).unwrap().clone(),
                 ];
                 let p3_my_encrypted_secret_shares = vec![
-                    p1_their_encrypted_secret_shares[2].clone(),
-                    p2_their_encrypted_secret_shares[2].clone(),
-                    p3_their_encrypted_secret_shares[2].clone(),
+                    p1_their_encrypted_secret_shares.get(&3).unwrap().clone(),
+                    p2_their_encrypted_secret_shares.get(&3).unwrap().clone(),
+                    p3_their_encrypted_secret_shares.get(&3).unwrap().clone(),
                 ];
 
                 let (p1_state, complaints) =
@@ -2620,25 +2766,26 @@ mod test {
                 )?;
             let p3_their_encrypted_secret_shares = p3_state.their_encrypted_secret_shares()?;
 
-            let mut wrong_encrypted_secret_share = p1_their_encrypted_secret_shares[1].clone();
+            let mut wrong_encrypted_secret_share =
+                p1_their_encrypted_secret_shares.get(&2).unwrap().clone();
             wrong_encrypted_secret_share.nonce = [42; 16];
 
             let p1_my_encrypted_secret_shares = vec![
-                p1_their_encrypted_secret_shares[0].clone(),
-                p2_their_encrypted_secret_shares[0].clone(),
-                p3_their_encrypted_secret_shares[0].clone(),
+                p1_their_encrypted_secret_shares.get(&1).unwrap().clone(),
+                p2_their_encrypted_secret_shares.get(&1).unwrap().clone(),
+                p3_their_encrypted_secret_shares.get(&1).unwrap().clone(),
             ];
 
             // Wrong share inserted here!
             let p2_my_encrypted_secret_shares = vec![
                 wrong_encrypted_secret_share.clone(),
-                p2_their_encrypted_secret_shares[1].clone(),
-                p3_their_encrypted_secret_shares[1].clone(),
+                p2_their_encrypted_secret_shares.get(&2).unwrap().clone(),
+                p3_their_encrypted_secret_shares.get(&2).unwrap().clone(),
             ];
             let p3_my_encrypted_secret_shares = vec![
-                p1_their_encrypted_secret_shares[2].clone(),
-                p2_their_encrypted_secret_shares[2].clone(),
-                p3_their_encrypted_secret_shares[2].clone(),
+                p1_their_encrypted_secret_shares.get(&3).unwrap().clone(),
+                p2_their_encrypted_secret_shares.get(&3).unwrap().clone(),
+                p3_their_encrypted_secret_shares.get(&3).unwrap().clone(),
             ];
 
             let (p1_state, complaints) =

--- a/src/dkg/key_generation.rs
+++ b/src/dkg/key_generation.rs
@@ -1061,6 +1061,10 @@ impl<C: CipherSuite> DistributedKeyGeneration<RoundTwo, C> {
     /// participants commitments and secret shares received from them, so that the key
     /// generation/resharing process can finish, in addition to returning the indices of the
     /// blamed participants.
+    ///
+    /// ***NOTE***: Participants *MUST* call this method before finishing the DKG/resharing phase,
+    /// and their list of complaints *MUST* include all complaints, otherwise they may have
+    /// inconsistent final states between them.
     pub fn blame(
         &mut self,
         encrypted_share: &EncryptedSecretShare<C>,

--- a/src/dkg/key_generation.rs
+++ b/src/dkg/key_generation.rs
@@ -1077,14 +1077,14 @@ impl<C: CipherSuite> DistributedKeyGeneration<RoundTwo, C> {
             return remove_malicious(self, complaint.maker_index);
         }
 
-        let commitment_accused = if let Some(idx) = self
+        let commitment_accused = if let Some(commitment) = self
             .state
             .their_commitments
             .as_ref()
             .unwrap()
             .get(&complaint.accused_index)
         {
-            idx
+            commitment
         } else {
             // We should have been able to retrieve commitments for the targeted index,
             // which means we already have removed this participant for misbehaviour.

--- a/src/dkg/key_generation.rs
+++ b/src/dkg/key_generation.rs
@@ -764,6 +764,12 @@ impl<C: CipherSuite> DistributedKeyGeneration<RoundOne, C> {
         }
 
         if !from_dealer && from_signer {
+            // Update the parameters with the total number of (valid) participants.
+            let parameters = ThresholdParameters::new(
+                parameters.n - misbehaving_participants.len() as u32,
+                parameters.t,
+            );
+
             let state = ActualState {
                 parameters,
                 index: my_index,
@@ -819,6 +825,12 @@ impl<C: CipherSuite> DistributedKeyGeneration<RoundOne, C> {
             their_encrypted_secret_shares
                 .insert(p.index, encrypt_share(&share, &dh_key_bytes[..], &mut rng)?);
         }
+
+        // Update the parameters with the total number of (valid) participants.
+        let parameters = ThresholdParameters::new(
+            parameters.n - misbehaving_participants.len() as u32,
+            parameters.t,
+        );
 
         let state = ActualState {
             parameters,

--- a/src/dkg/key_generation.rs
+++ b/src/dkg/key_generation.rs
@@ -879,7 +879,9 @@ impl<C: CipherSuite> DistributedKeyGeneration<RoundOne, C> {
 
         let mut complaints: Vec<Complaint<C>> = Vec::new();
 
-        if my_encrypted_secret_shares.len() != self.state.parameters.n as usize {
+        // This should in theory never happen, as users should make sure they don't call this
+        // method before having received all the encrypted secret shares they expect.
+        if my_encrypted_secret_shares.len() < self.state.parameters.t as usize {
             return Err(Error::MissingShares);
         }
 

--- a/src/dkg/key_generation.rs
+++ b/src/dkg/key_generation.rs
@@ -2162,6 +2162,11 @@ mod test {
                     .to_round_two(p2_my_encrypted_secret_shares, rng)?;
                 assert!(complaints.len() == 1);
 
+                // Anyone can blame the malicious participant.
+                let bad_index = p1_state.blame(&wrong_encrypted_secret_share, &complaints[0]);
+                assert!(bad_index == 1);
+                let bad_index = p2_state.blame(&wrong_encrypted_secret_share, &complaints[0]);
+                assert!(bad_index == 1);
                 let bad_index = p3_state.blame(&wrong_encrypted_secret_share, &complaints[0]);
                 assert!(bad_index == 1);
 
@@ -2213,6 +2218,11 @@ mod test {
                     .to_round_two(p2_my_encrypted_secret_shares, rng)?;
                 assert!(complaints.len() == 1);
 
+                // Anyone can blame the malicious participant.
+                let bad_index = p1_state.blame(&wrong_encrypted_secret_share, &complaints[0]);
+                assert!(bad_index == 1);
+                let bad_index = p2_state.blame(&wrong_encrypted_secret_share, &complaints[0]);
+                assert!(bad_index == 1);
                 let bad_index = p3_state.blame(&wrong_encrypted_secret_share, &complaints[0]);
                 assert!(bad_index == 1);
 
@@ -2270,6 +2280,11 @@ mod test {
                     .to_round_two(p2_my_encrypted_secret_shares, rng)?;
                 assert!(complaints.len() == 1);
 
+                // Anyone can blame the malicious participant.
+                let bad_index = p1_state.blame(&wrong_encrypted_secret_share, &complaints[0]);
+                assert!(bad_index == 1);
+                let bad_index = p2_state.blame(&wrong_encrypted_secret_share, &complaints[0]);
+                assert!(bad_index == 1);
                 let bad_index = p3_state.blame(&wrong_encrypted_secret_share, &complaints[0]);
                 assert!(bad_index == 1);
 

--- a/src/dkg/key_generation.rs
+++ b/src/dkg/key_generation.rs
@@ -1119,7 +1119,7 @@ impl<C: CipherSuite> DistributedKeyGeneration<RoundTwo, C> {
         if share.is_err() {
             return remove_malicious(self, complaint.accused_index);
         };
-        match share.unwrap().verify(&commitment_accused) {
+        match share.unwrap().verify(commitment_accused) {
             Ok(()) => remove_malicious(self, complaint.maker_index),
             Err(_) => remove_malicious(self, complaint.accused_index),
         }

--- a/src/dkg/participant.rs
+++ b/src/dkg/participant.rs
@@ -21,7 +21,7 @@ use crate::parameters::ThresholdParameters;
 use crate::serialization::impl_serialization_traits;
 use crate::{Error, FrostResult};
 
-use crate::utils::{Scalar, Vec};
+use crate::utils::{BTreeMap, Scalar, Vec};
 
 use super::DKGParticipantList;
 use super::DistributedKeyGeneration;
@@ -240,7 +240,14 @@ impl<C: CipherSuite> Participant<C> {
         secret_key: IndividualSigningKey<C>,
         signers: &[Participant<C>],
         mut rng: impl RngCore + CryptoRng,
-    ) -> FrostResult<C, (Self, Vec<EncryptedSecretShare<C>>, DKGParticipantList<C>)> {
+    ) -> FrostResult<
+        C,
+        (
+            Self,
+            BTreeMap<u32, EncryptedSecretShare<C>>,
+            DKGParticipantList<C>,
+        ),
+    > {
         let (dealer, coeff_option, dh_private_key) = Self::new_internal(
             parameters,
             false,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -360,9 +360,14 @@
 //! #                                   bob_their_encrypted_secret_shares[2].clone(),
 //! #                                   carol_their_encrypted_secret_shares[2].clone()];
 //! #
-//! let alice_state = alice_state.to_round_two(alice_my_encrypted_secret_shares, &mut rng)?;
-//! let bob_state = bob_state.to_round_two(bob_my_encrypted_secret_shares, &mut rng)?;
-//! let carol_state = carol_state.to_round_two(carol_my_encrypted_secret_shares, &mut rng)?;
+//! let (alice_state, alice_complaints) = alice_state.to_round_two(alice_my_encrypted_secret_shares, &mut rng)?;
+//! let (bob_state, bob_complaints) = bob_state.to_round_two(bob_my_encrypted_secret_shares, &mut rng)?;
+//! let (carol_state, carol_complaints) = carol_state.to_round_two(carol_my_encrypted_secret_shares, &mut rng)?;
+//!
+//! // Everything should have run smoothly.
+//! assert!(alice_complaints.is_empty());
+//! assert!(bob_complaints.is_empty());
+//! assert!(carol_complaints.is_empty());
 //! # Ok(()) } fn main() { assert!(do_test().is_ok()); }
 //! ```
 //!
@@ -413,9 +418,9 @@
 //! #                                   bob_their_encrypted_secret_shares[2].clone(),
 //! #                                   carol_their_encrypted_secret_shares[2].clone()];
 //! #
-//! # let alice_state = alice_state.to_round_two(alice_my_encrypted_secret_shares, &mut rng)?;
-//! # let bob_state = bob_state.to_round_two(bob_my_encrypted_secret_shares, &mut rng)?;
-//! # let carol_state = carol_state.to_round_two(carol_my_encrypted_secret_shares, &mut rng)?;
+//! # let (alice_state, _) = alice_state.to_round_two(alice_my_encrypted_secret_shares, &mut rng)?;
+//! # let (bob_state, _) = bob_state.to_round_two(bob_my_encrypted_secret_shares, &mut rng)?;
+//! # let (carol_state, _) = carol_state.to_round_two(carol_my_encrypted_secret_shares, &mut rng)?;
 //! #
 //! let (alice_group_key, alice_secret_key) = alice_state.finish()?;
 //! let (bob_group_key, bob_secret_key) = bob_state.finish()?;
@@ -481,9 +486,9 @@
 //! #                                   bob_their_encrypted_secret_shares[2].clone(),
 //! #                                   carol_their_encrypted_secret_shares[2].clone()];
 //! #
-//! # let alice_state = alice_state.to_round_two(alice_my_encrypted_secret_shares, &mut rng)?;
-//! # let bob_state = bob_state.to_round_two(bob_my_encrypted_secret_shares, &mut rng)?;
-//! # let carol_state = carol_state.to_round_two(carol_my_encrypted_secret_shares, &mut rng)?;
+//! # let (alice_state, _) = alice_state.to_round_two(alice_my_encrypted_secret_shares, &mut rng)?;
+//! # let (bob_state, _) = bob_state.to_round_two(bob_my_encrypted_secret_shares, &mut rng)?;
+//! # let (carol_state, _) = carol_state.to_round_two(carol_my_encrypted_secret_shares, &mut rng)?;
 //!
 //! let (alice_group_key, alice_secret_key) = alice_state.finish()?;
 //! let (bob_group_key, bob_secret_key) = bob_state.finish()?;
@@ -559,9 +564,9 @@
 //! #                                   bob_their_encrypted_secret_shares[2].clone(),
 //! #                                   carol_their_encrypted_secret_shares[2].clone()];
 //! #
-//! # let alice_state = alice_state.to_round_two(alice_my_encrypted_secret_shares, &mut rng)?;
-//! # let bob_state = bob_state.to_round_two(bob_my_encrypted_secret_shares, &mut rng)?;
-//! # let carol_state = carol_state.to_round_two(carol_my_encrypted_secret_shares, &mut rng)?;
+//! # let (alice_state, _) = alice_state.to_round_two(alice_my_encrypted_secret_shares, &mut rng)?;
+//! # let (bob_state, _) = bob_state.to_round_two(bob_my_encrypted_secret_shares, &mut rng)?;
+//! # let (carol_state, _) = carol_state.to_round_two(carol_my_encrypted_secret_shares, &mut rng)?;
 //! #
 //! # let (alice_group_key, alice_secret_key) = alice_state.finish()?;
 //! # let (bob_group_key, bob_secret_key) = bob_state.finish()?;
@@ -674,9 +679,9 @@
 //! #                                   bob_their_encrypted_secret_shares[2].clone(),
 //! #                                   carol_their_encrypted_secret_shares[2].clone()];
 //! #
-//! # let alice_state = alice_state.to_round_two(alice_my_encrypted_secret_shares, &mut rng)?;
-//! # let bob_state = bob_state.to_round_two(bob_my_encrypted_secret_shares, &mut rng)?;
-//! # let carol_state = carol_state.to_round_two(carol_my_encrypted_secret_shares, &mut rng)?;
+//! # let (alice_state, _) = alice_state.to_round_two(alice_my_encrypted_secret_shares, &mut rng)?;
+//! # let (bob_state, _) = bob_state.to_round_two(bob_my_encrypted_secret_shares, &mut rng)?;
+//! # let (carol_state, _) = carol_state.to_round_two(carol_my_encrypted_secret_shares, &mut rng)?;
 //! #
 //! # let (alice_group_key, alice_secret_key) = alice_state.finish()?;
 //! # let (bob_group_key, bob_secret_key) = bob_state.finish()?;
@@ -728,10 +733,16 @@
 //! #                                   bob_encrypted_shares[3].clone(),
 //! #                                   carol_encrypted_shares[3].clone()];
 //! #
-//! let alexis_state = alexis_state.to_round_two(alexis_my_encrypted_secret_shares, &mut rng)?;
-//! let barbara_state = barbara_state.to_round_two(barbara_my_encrypted_secret_shares, &mut rng)?;
-//! let claire_state = claire_state.to_round_two(claire_my_encrypted_secret_shares, &mut rng)?;
-//! let david_state = david_state.to_round_two(david_my_encrypted_secret_shares, &mut rng)?;
+//! let (alexis_state, alexis_complaints) = alexis_state.to_round_two(alexis_my_encrypted_secret_shares, &mut rng)?;
+//! let (barbara_state, barbara_complaints) = barbara_state.to_round_two(barbara_my_encrypted_secret_shares, &mut rng)?;
+//! let (claire_state, claire_complaints) = claire_state.to_round_two(claire_my_encrypted_secret_shares, &mut rng)?;
+//! let (david_state, david_complaints) = david_state.to_round_two(david_my_encrypted_secret_shares, &mut rng)?;
+//!
+//! // Everything should have run smoothly.
+//! assert!(alexis_complaints.is_empty());
+//! assert!(barbara_complaints.is_empty());
+//! assert!(claire_complaints.is_empty());
+//! assert!(david_complaints.is_empty());
 //! # Ok(()) } fn main() { assert!(do_test().is_ok()); }
 //! ```
 //!
@@ -781,9 +792,9 @@
 //! #                                   bob_their_encrypted_secret_shares[2].clone(),
 //! #                                   carol_their_encrypted_secret_shares[2].clone()];
 //! #
-//! # let alice_state = alice_state.to_round_two(alice_my_encrypted_secret_shares, &mut rng)?;
-//! # let bob_state = bob_state.to_round_two(bob_my_encrypted_secret_shares, &mut rng)?;
-//! # let carol_state = carol_state.to_round_two(carol_my_encrypted_secret_shares, &mut rng)?;
+//! # let (alice_state, _) = alice_state.to_round_two(alice_my_encrypted_secret_shares, &mut rng)?;
+//! # let (bob_state, _) = bob_state.to_round_two(bob_my_encrypted_secret_shares, &mut rng)?;
+//! # let (carol_state, _) = carol_state.to_round_two(carol_my_encrypted_secret_shares, &mut rng)?;
 //! #
 //! # let (alice_group_key, alice_secret_key) = alice_state.finish()?;
 //! # let (bob_group_key, bob_secret_key) = bob_state.finish()?;
@@ -833,10 +844,10 @@
 //! #                                   bob_encrypted_shares[3].clone(),
 //! #                                   carol_encrypted_shares[3].clone()];
 //! #
-//! # let alexis_state = alexis_state.to_round_two(alexis_my_encrypted_secret_shares, &mut rng)?;
-//! # let barbara_state = barbara_state.to_round_two(barbara_my_encrypted_secret_shares, &mut rng)?;
-//! # let claire_state = claire_state.to_round_two(claire_my_encrypted_secret_shares, &mut rng)?;
-//! # let david_state = david_state.to_round_two(david_my_encrypted_secret_shares, &mut rng)?;
+//! # let (alexis_state, _) = alexis_state.to_round_two(alexis_my_encrypted_secret_shares, &mut rng)?;
+//! # let (barbara_state, _) = barbara_state.to_round_two(barbara_my_encrypted_secret_shares, &mut rng)?;
+//! # let (claire_state, _) = claire_state.to_round_two(claire_my_encrypted_secret_shares, &mut rng)?;
+//! # let (david_state, _) = david_state.to_round_two(david_my_encrypted_secret_shares, &mut rng)?;
 //! #
 //! let (alexis_group_key, alexis_secret_key) = alexis_state.finish()?;
 //! let (barbara_group_key, barbara_secret_key) = barbara_state.finish()?;
@@ -900,9 +911,9 @@
 //! #                                   bob_their_encrypted_secret_shares[2].clone(),
 //! #                                   carol_their_encrypted_secret_shares[2].clone()];
 //! #
-//! # let alice_state = alice_state.to_round_two(alice_my_encrypted_secret_shares, &mut rng)?;
-//! # let bob_state = bob_state.to_round_two(bob_my_encrypted_secret_shares, &mut rng)?;
-//! # let carol_state = carol_state.to_round_two(carol_my_encrypted_secret_shares, &mut rng)?;
+//! # let (alice_state, _) = alice_state.to_round_two(alice_my_encrypted_secret_shares, &mut rng)?;
+//! # let (bob_state, _) = bob_state.to_round_two(bob_my_encrypted_secret_shares, &mut rng)?;
+//! # let (carol_state, _) = carol_state.to_round_two(carol_my_encrypted_secret_shares, &mut rng)?;
 //! #
 //! # let (alice_group_key, alice_secret_key) = alice_state.finish()?;
 //! # let (bob_group_key, bob_secret_key) = bob_state.finish()?;
@@ -979,9 +990,9 @@
 //! #                                   bob_their_encrypted_secret_shares[2].clone(),
 //! #                                   carol_their_encrypted_secret_shares[2].clone()];
 //! #
-//! # let alice_state = alice_state.to_round_two(alice_my_encrypted_secret_shares, &mut rng)?;
-//! # let bob_state = bob_state.to_round_two(bob_my_encrypted_secret_shares, &mut rng)?;
-//! # let carol_state = carol_state.to_round_two(carol_my_encrypted_secret_shares, &mut rng)?;
+//! # let (alice_state, _) = alice_state.to_round_two(alice_my_encrypted_secret_shares, &mut rng)?;
+//! # let (bob_state, _) = bob_state.to_round_two(bob_my_encrypted_secret_shares, &mut rng)?;
+//! # let (carol_state, _) = carol_state.to_round_two(carol_my_encrypted_secret_shares, &mut rng)?;
 //! #
 //! # let (alice_group_key, alice_secret_key) = alice_state.finish()?;
 //! # let (bob_group_key, bob_secret_key) = bob_state.finish()?;
@@ -1053,9 +1064,9 @@
 //! #                                   bob_their_encrypted_secret_shares[2].clone(),
 //! #                                   carol_their_encrypted_secret_shares[2].clone()];
 //! #
-//! # let alice_state = alice_state.to_round_two(alice_my_encrypted_secret_shares, &mut rng)?;
-//! # let bob_state = bob_state.to_round_two(bob_my_encrypted_secret_shares, &mut rng)?;
-//! # let carol_state = carol_state.to_round_two(carol_my_encrypted_secret_shares, &mut rng)?;
+//! # let (alice_state, _) = alice_state.to_round_two(alice_my_encrypted_secret_shares, &mut rng)?;
+//! # let (bob_state, _) = bob_state.to_round_two(bob_my_encrypted_secret_shares, &mut rng)?;
+//! # let (carol_state, _) = carol_state.to_round_two(carol_my_encrypted_secret_shares, &mut rng)?;
 //! #
 //! # let (alice_group_key, alice_secret_key) = alice_state.finish()?;
 //! # let (bob_group_key, bob_secret_key) = bob_state.finish()?;
@@ -1127,9 +1138,9 @@
 //! #                                   bob_their_encrypted_secret_shares[2].clone(),
 //! #                                   carol_their_encrypted_secret_shares[2].clone()];
 //! #
-//! # let alice_state = alice_state.to_round_two(alice_my_encrypted_secret_shares, &mut rng)?;
-//! # let bob_state = bob_state.to_round_two(bob_my_encrypted_secret_shares, &mut rng)?;
-//! # let carol_state = carol_state.to_round_two(carol_my_encrypted_secret_shares, &mut rng)?;
+//! # let (alice_state, _) = alice_state.to_round_two(alice_my_encrypted_secret_shares, &mut rng)?;
+//! # let (bob_state, _) = bob_state.to_round_two(bob_my_encrypted_secret_shares, &mut rng)?;
+//! # let (carol_state, _) = carol_state.to_round_two(carol_my_encrypted_secret_shares, &mut rng)?;
 //! #
 //! # let (alice_group_key, alice_secret_key) = alice_state.finish()?;
 //! # let (bob_group_key, bob_secret_key) = bob_state.finish()?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -201,8 +201,8 @@
 //!
 //! let bob_their_encrypted_secret_shares = bob_state.their_encrypted_secret_shares()?;
 //!
-//! // send_to_alice(bob_their_encrypted_secret_shares[0]);
-//! // send_to_carol(bob_their_encrypted_secret_shares[1]);
+//! // send_to_alice(bob_their_encrypted_secret_shares.get(&alice.index).unwrap());
+//! // send_to_carol(bob_their_encrypted_secret_shares.get(&bob.index).unwrap());
 //! # Ok(()) } fn main() { assert!(do_test().is_ok()); assert!(do_test2().is_ok()); }
 //! ```
 //!
@@ -253,8 +253,8 @@
 //!
 //! let carol_their_encrypted_secret_shares = carol_state.their_encrypted_secret_shares()?;
 //!
-//! // send_to_alice(carol_their_encrypted_secret_shares[0]);
-//! // send_to_bob(carol_their_encrypted_secret_shares[1]);
+//! // send_to_alice(carol_their_encrypted_secret_shares.get(&alice.index).unwrap());
+//! // send_to_bob(carol_their_encrypted_secret_shares.get(&bob.index).unwrap());
 //! # Ok(()) } fn main() { assert!(do_test().is_ok()); assert!(do_test2().is_ok()); }
 //! ```
 //!
@@ -293,19 +293,19 @@
 //! #                                                      &participants, &mut rng)?;
 //! # let carol_their_encrypted_secret_shares = carol_state.their_encrypted_secret_shares()?;
 //! let alice_my_encrypted_secret_shares = vec![
-//!     alice_their_encrypted_secret_shares[0].clone(),
-//!     bob_their_encrypted_secret_shares[0].clone(),
-//!     carol_their_encrypted_secret_shares[0].clone(),
+//!     alice_their_encrypted_secret_shares.get(&alice.index).unwrap().clone(),
+//!     bob_their_encrypted_secret_shares.get(&alice.index).unwrap().clone(),
+//!     carol_their_encrypted_secret_shares.get(&alice.index).unwrap().clone(),
 //! ];
 //! let bob_my_encrypted_secret_shares = vec![
-//!     alice_their_encrypted_secret_shares[1].clone(),
-//!     bob_their_encrypted_secret_shares[1].clone(),
-//!     carol_their_encrypted_secret_shares[1].clone(),
+//!     alice_their_encrypted_secret_shares.get(&bob.index).unwrap().clone(),
+//!     bob_their_encrypted_secret_shares.get(&bob.index).unwrap().clone(),
+//!     carol_their_encrypted_secret_shares.get(&bob.index).unwrap().clone(),
 //! ];
 //! let carol_my_encrypted_secret_shares = vec![
-//!     alice_their_encrypted_secret_shares[2].clone(),
-//!     bob_their_encrypted_secret_shares[2].clone(),
-//!     carol_their_encrypted_secret_shares[2].clone(),
+//!     alice_their_encrypted_secret_shares.get(&carol.index).unwrap().clone(),
+//!     bob_their_encrypted_secret_shares.get(&carol.index).unwrap().clone(),
+//!     carol_their_encrypted_secret_shares.get(&carol.index).unwrap().clone(),
 //! ];
 //! # Ok(()) } fn main() { assert!(do_test().is_ok()); }
 //! ```
@@ -350,15 +350,15 @@
 //! # let (carol_state, participant_lists) = DistributedKeyGeneration::<_, Secp256k1Sha256>::bootstrap(&params, &carol_dh_sk, &carol.index, &carol_coefficients,
 //! #                                                      &participants, &mut rng)?;
 //! # let carol_their_encrypted_secret_shares = carol_state.their_encrypted_secret_shares()?;
-//! # let alice_my_encrypted_secret_shares = vec![alice_their_encrypted_secret_shares[0].clone(),
-//! #                                   bob_their_encrypted_secret_shares[0].clone(),
-//! #                                   carol_their_encrypted_secret_shares[0].clone()];
-//! # let bob_my_encrypted_secret_shares = vec![alice_their_encrypted_secret_shares[1].clone(),
-//! #                                 bob_their_encrypted_secret_shares[1].clone(),
-//! #                                 carol_their_encrypted_secret_shares[1].clone()];
-//! # let carol_my_encrypted_secret_shares = vec![alice_their_encrypted_secret_shares[2].clone(),
-//! #                                   bob_their_encrypted_secret_shares[2].clone(),
-//! #                                   carol_their_encrypted_secret_shares[2].clone()];
+//! # let alice_my_encrypted_secret_shares = vec![alice_their_encrypted_secret_shares.get(&alice.index).unwrap().clone(),
+//! #                                   bob_their_encrypted_secret_shares.get(&alice.index).unwrap().clone(),
+//! #                                   carol_their_encrypted_secret_shares.get(&alice.index).unwrap().clone()];
+//! # let bob_my_encrypted_secret_shares = vec![alice_their_encrypted_secret_shares.get(&bob.index).unwrap().clone(),
+//! #                                 bob_their_encrypted_secret_shares.get(&bob.index).unwrap().clone(),
+//! #                                 carol_their_encrypted_secret_shares.get(&bob.index).unwrap().clone()];
+//! # let carol_my_encrypted_secret_shares = vec![alice_their_encrypted_secret_shares.get(&carol.index).unwrap().clone(),
+//! #                                   bob_their_encrypted_secret_shares.get(&carol.index).unwrap().clone(),
+//! #                                   carol_their_encrypted_secret_shares.get(&carol.index).unwrap().clone()];
 //! #
 //! let (alice_state, alice_complaints) = alice_state.to_round_two(alice_my_encrypted_secret_shares, &mut rng)?;
 //! let (bob_state, bob_complaints) = bob_state.to_round_two(bob_my_encrypted_secret_shares, &mut rng)?;
@@ -408,15 +408,15 @@
 //! # let (carol_state, participant_lists) = DistributedKeyGeneration::<_, Secp256k1Sha256>::bootstrap(&params, &carol_dh_sk, &carol.index, &carol_coefficients,
 //! #                                                      &participants, &mut rng)?;
 //! # let carol_their_encrypted_secret_shares = carol_state.their_encrypted_secret_shares()?;
-//! # let alice_my_encrypted_secret_shares = vec![alice_their_encrypted_secret_shares[0].clone(),
-//! #                                   bob_their_encrypted_secret_shares[0].clone(),
-//! #                                   carol_their_encrypted_secret_shares[0].clone()];
-//! # let bob_my_encrypted_secret_shares = vec![alice_their_encrypted_secret_shares[1].clone(),
-//! #                                 bob_their_encrypted_secret_shares[1].clone(),
-//! #                                 carol_their_encrypted_secret_shares[1].clone()];
-//! # let carol_my_encrypted_secret_shares = vec![alice_their_encrypted_secret_shares[2].clone(),
-//! #                                   bob_their_encrypted_secret_shares[2].clone(),
-//! #                                   carol_their_encrypted_secret_shares[2].clone()];
+//! # let alice_my_encrypted_secret_shares = vec![alice_their_encrypted_secret_shares.get(&alice.index).unwrap().clone(),
+//! #                                   bob_their_encrypted_secret_shares.get(&alice.index).unwrap().clone(),
+//! #                                   carol_their_encrypted_secret_shares.get(&alice.index).unwrap().clone()];
+//! # let bob_my_encrypted_secret_shares = vec![alice_their_encrypted_secret_shares.get(&bob.index).unwrap().clone(),
+//! #                                 bob_their_encrypted_secret_shares.get(&bob.index).unwrap().clone(),
+//! #                                 carol_their_encrypted_secret_shares.get(&bob.index).unwrap().clone()];
+//! # let carol_my_encrypted_secret_shares = vec![alice_their_encrypted_secret_shares.get(&carol.index).unwrap().clone(),
+//! #                                   bob_their_encrypted_secret_shares.get(&carol.index).unwrap().clone(),
+//! #                                   carol_their_encrypted_secret_shares.get(&carol.index).unwrap().clone()];
 //! #
 //! # let (alice_state, _) = alice_state.to_round_two(alice_my_encrypted_secret_shares, &mut rng)?;
 //! # let (bob_state, _) = bob_state.to_round_two(bob_my_encrypted_secret_shares, &mut rng)?;
@@ -476,15 +476,15 @@
 //! # let (carol_state, participant_lists) = DistributedKeyGeneration::<_, Secp256k1Sha256>::bootstrap(&params, &carol_dh_sk, &carol.index, &carol_coefficients,
 //! #                                                      &participants, &mut rng)?;
 //! # let carol_their_encrypted_secret_shares = carol_state.their_encrypted_secret_shares()?;
-//! # let alice_my_encrypted_secret_shares = vec![alice_their_encrypted_secret_shares[0].clone(),
-//! #                                   bob_their_encrypted_secret_shares[0].clone(),
-//! #                                   carol_their_encrypted_secret_shares[0].clone()];
-//! # let bob_my_encrypted_secret_shares = vec![alice_their_encrypted_secret_shares[1].clone(),
-//! #                                 bob_their_encrypted_secret_shares[1].clone(),
-//! #                                 carol_their_encrypted_secret_shares[1].clone()];
-//! # let carol_my_encrypted_secret_shares = vec![alice_their_encrypted_secret_shares[2].clone(),
-//! #                                   bob_their_encrypted_secret_shares[2].clone(),
-//! #                                   carol_their_encrypted_secret_shares[2].clone()];
+//! # let alice_my_encrypted_secret_shares = vec![alice_their_encrypted_secret_shares.get(&alice.index).unwrap().clone(),
+//! #                                   bob_their_encrypted_secret_shares.get(&alice.index).unwrap().clone(),
+//! #                                   carol_their_encrypted_secret_shares.get(&alice.index).unwrap().clone()];
+//! # let bob_my_encrypted_secret_shares = vec![alice_their_encrypted_secret_shares.get(&bob.index).unwrap().clone(),
+//! #                                 bob_their_encrypted_secret_shares.get(&bob.index).unwrap().clone(),
+//! #                                 carol_their_encrypted_secret_shares.get(&bob.index).unwrap().clone()];
+//! # let carol_my_encrypted_secret_shares = vec![alice_their_encrypted_secret_shares.get(&carol.index).unwrap().clone(),
+//! #                                   bob_their_encrypted_secret_shares.get(&carol.index).unwrap().clone(),
+//! #                                   carol_their_encrypted_secret_shares.get(&carol.index).unwrap().clone()];
 //! #
 //! # let (alice_state, _) = alice_state.to_round_two(alice_my_encrypted_secret_shares, &mut rng)?;
 //! # let (bob_state, _) = bob_state.to_round_two(bob_my_encrypted_secret_shares, &mut rng)?;
@@ -554,15 +554,15 @@
 //! # let (carol_state, participant_lists) = DistributedKeyGeneration::<_, Secp256k1Sha256>::bootstrap(&params, &carol_dh_sk, &carol.index, &carol_coefficients,
 //! #                                                      &participants, &mut rng)?;
 //! # let carol_their_encrypted_secret_shares = carol_state.their_encrypted_secret_shares()?;
-//! # let alice_my_encrypted_secret_shares = vec![alice_their_encrypted_secret_shares[0].clone(),
-//! #                                   bob_their_encrypted_secret_shares[0].clone(),
-//! #                                   carol_their_encrypted_secret_shares[0].clone()];
-//! # let bob_my_encrypted_secret_shares = vec![alice_their_encrypted_secret_shares[1].clone(),
-//! #                                 bob_their_encrypted_secret_shares[1].clone(),
-//! #                                 carol_their_encrypted_secret_shares[1].clone()];
-//! # let carol_my_encrypted_secret_shares = vec![alice_their_encrypted_secret_shares[2].clone(),
-//! #                                   bob_their_encrypted_secret_shares[2].clone(),
-//! #                                   carol_their_encrypted_secret_shares[2].clone()];
+//! # let alice_my_encrypted_secret_shares = vec![alice_their_encrypted_secret_shares.get(&alice.index).unwrap().clone(),
+//! #                                   bob_their_encrypted_secret_shares.get(&alice.index).unwrap().clone(),
+//! #                                   carol_their_encrypted_secret_shares.get(&alice.index).unwrap().clone()];
+//! # let bob_my_encrypted_secret_shares = vec![alice_their_encrypted_secret_shares.get(&bob.index).unwrap().clone(),
+//! #                                 bob_their_encrypted_secret_shares.get(&bob.index).unwrap().clone(),
+//! #                                 carol_their_encrypted_secret_shares.get(&bob.index).unwrap().clone()];
+//! # let carol_my_encrypted_secret_shares = vec![alice_their_encrypted_secret_shares.get(&carol.index).unwrap().clone(),
+//! #                                   bob_their_encrypted_secret_shares.get(&carol.index).unwrap().clone(),
+//! #                                   carol_their_encrypted_secret_shares.get(&carol.index).unwrap().clone()];
 //! #
 //! # let (alice_state, _) = alice_state.to_round_two(alice_my_encrypted_secret_shares, &mut rng)?;
 //! # let (bob_state, _) = bob_state.to_round_two(bob_my_encrypted_secret_shares, &mut rng)?;
@@ -669,15 +669,15 @@
 //! # let (carol_state, participant_lists) = DistributedKeyGeneration::<_, Secp256k1Sha256>::bootstrap(&params, &carol_dh_sk, &carol.index, &carol_coefficients,
 //! #                                                      &participants, &mut rng)?;
 //! # let carol_their_encrypted_secret_shares = carol_state.their_encrypted_secret_shares()?;
-//! # let alice_my_encrypted_secret_shares = vec![alice_their_encrypted_secret_shares[0].clone(),
-//! #                                   bob_their_encrypted_secret_shares[0].clone(),
-//! #                                   carol_their_encrypted_secret_shares[0].clone()];
-//! # let bob_my_encrypted_secret_shares = vec![alice_their_encrypted_secret_shares[1].clone(),
-//! #                                 bob_their_encrypted_secret_shares[1].clone(),
-//! #                                 carol_their_encrypted_secret_shares[1].clone()];
-//! # let carol_my_encrypted_secret_shares = vec![alice_their_encrypted_secret_shares[2].clone(),
-//! #                                   bob_their_encrypted_secret_shares[2].clone(),
-//! #                                   carol_their_encrypted_secret_shares[2].clone()];
+//! # let alice_my_encrypted_secret_shares = vec![alice_their_encrypted_secret_shares.get(&alice.index).unwrap().clone(),
+//! #                                   bob_their_encrypted_secret_shares.get(&alice.index).unwrap().clone(),
+//! #                                   carol_their_encrypted_secret_shares.get(&alice.index).unwrap().clone()];
+//! # let bob_my_encrypted_secret_shares = vec![alice_their_encrypted_secret_shares.get(&bob.index).unwrap().clone(),
+//! #                                 bob_their_encrypted_secret_shares.get(&bob.index).unwrap().clone(),
+//! #                                 carol_their_encrypted_secret_shares.get(&bob.index).unwrap().clone()];
+//! # let carol_my_encrypted_secret_shares = vec![alice_their_encrypted_secret_shares.get(&carol.index).unwrap().clone(),
+//! #                                   bob_their_encrypted_secret_shares.get(&carol.index).unwrap().clone(),
+//! #                                   carol_their_encrypted_secret_shares.get(&carol.index).unwrap().clone()];
 //! #
 //! # let (alice_state, _) = alice_state.to_round_two(alice_my_encrypted_secret_shares, &mut rng)?;
 //! # let (bob_state, _) = bob_state.to_round_two(bob_my_encrypted_secret_shares, &mut rng)?;
@@ -720,18 +720,18 @@
 //! # let (david_state, participant_lists) = DistributedKeyGeneration::<_, Secp256k1Sha256>::new(&params, &david_dh_sk, &david.index,
 //! #                                                      &dealers, &mut rng)?;
 //! #
-//! # let alexis_my_encrypted_secret_shares = vec![alice_encrypted_shares[0].clone(),
-//! #                                   bob_encrypted_shares[0].clone(),
-//! #                                   carol_encrypted_shares[0].clone()];
-//! # let barbara_my_encrypted_secret_shares = vec![alice_encrypted_shares[1].clone(),
-//! #                                   bob_encrypted_shares[1].clone(),
-//! #                                   carol_encrypted_shares[1].clone()];
-//! # let claire_my_encrypted_secret_shares = vec![alice_encrypted_shares[2].clone(),
-//! #                                   bob_encrypted_shares[2].clone(),
-//! #                                   carol_encrypted_shares[2].clone()];
-//! # let david_my_encrypted_secret_shares = vec![alice_encrypted_shares[3].clone(),
-//! #                                   bob_encrypted_shares[3].clone(),
-//! #                                   carol_encrypted_shares[3].clone()];
+//! # let alexis_my_encrypted_secret_shares = vec![alice_encrypted_shares.get(&alexis.index).unwrap().clone(),
+//! #                                   bob_encrypted_shares.get(&alexis.index).unwrap().clone(),
+//! #                                   carol_encrypted_shares.get(&alexis.index).unwrap().clone()];
+//! # let barbara_my_encrypted_secret_shares = vec![alice_encrypted_shares.get(&barbara.index).unwrap().clone(),
+//! #                                   bob_encrypted_shares.get(&barbara.index).unwrap().clone(),
+//! #                                   carol_encrypted_shares.get(&barbara.index).unwrap().clone()];
+//! # let claire_my_encrypted_secret_shares = vec![alice_encrypted_shares.get(&claire.index).unwrap().clone(),
+//! #                                   bob_encrypted_shares.get(&claire.index).unwrap().clone(),
+//! #                                   carol_encrypted_shares.get(&claire.index).unwrap().clone()];
+//! # let david_my_encrypted_secret_shares = vec![alice_encrypted_shares.get(&david.index).unwrap().clone(),
+//! #                                   bob_encrypted_shares.get(&david.index).unwrap().clone(),
+//! #                                   carol_encrypted_shares.get(&david.index).unwrap().clone()];
 //! #
 //! let (alexis_state, alexis_complaints) = alexis_state.to_round_two(alexis_my_encrypted_secret_shares, &mut rng)?;
 //! let (barbara_state, barbara_complaints) = barbara_state.to_round_two(barbara_my_encrypted_secret_shares, &mut rng)?;
@@ -782,15 +782,15 @@
 //! # let (carol_state, participant_lists) = DistributedKeyGeneration::<_, Secp256k1Sha256>::bootstrap(&params, &carol_dh_sk, &carol.index, &carol_coefficients,
 //! #                                                      &participants, &mut rng)?;
 //! # let carol_their_encrypted_secret_shares = carol_state.their_encrypted_secret_shares()?;
-//! # let alice_my_encrypted_secret_shares = vec![alice_their_encrypted_secret_shares[0].clone(),
-//! #                                   bob_their_encrypted_secret_shares[0].clone(),
-//! #                                   carol_their_encrypted_secret_shares[0].clone()];
-//! # let bob_my_encrypted_secret_shares = vec![alice_their_encrypted_secret_shares[1].clone(),
-//! #                                 bob_their_encrypted_secret_shares[1].clone(),
-//! #                                 carol_their_encrypted_secret_shares[1].clone()];
-//! # let carol_my_encrypted_secret_shares = vec![alice_their_encrypted_secret_shares[2].clone(),
-//! #                                   bob_their_encrypted_secret_shares[2].clone(),
-//! #                                   carol_their_encrypted_secret_shares[2].clone()];
+//! # let alice_my_encrypted_secret_shares = vec![alice_their_encrypted_secret_shares.get(&alice.index).unwrap().clone(),
+//! #                                   bob_their_encrypted_secret_shares.get(&alice.index).unwrap().clone(),
+//! #                                   carol_their_encrypted_secret_shares.get(&alice.index).unwrap().clone()];
+//! # let bob_my_encrypted_secret_shares = vec![alice_their_encrypted_secret_shares.get(&bob.index).unwrap().clone(),
+//! #                                 bob_their_encrypted_secret_shares.get(&bob.index).unwrap().clone(),
+//! #                                 carol_their_encrypted_secret_shares.get(&bob.index).unwrap().clone()];
+//! # let carol_my_encrypted_secret_shares = vec![alice_their_encrypted_secret_shares.get(&carol.index).unwrap().clone(),
+//! #                                   bob_their_encrypted_secret_shares.get(&carol.index).unwrap().clone(),
+//! #                                   carol_their_encrypted_secret_shares.get(&carol.index).unwrap().clone()];
 //! #
 //! # let (alice_state, _) = alice_state.to_round_two(alice_my_encrypted_secret_shares, &mut rng)?;
 //! # let (bob_state, _) = bob_state.to_round_two(bob_my_encrypted_secret_shares, &mut rng)?;
@@ -831,18 +831,18 @@
 //! # let (david_state, participant_lists) = DistributedKeyGeneration::<_, Secp256k1Sha256>::new(&params, &david_dh_sk, &david.index,
 //! #                                                      &dealers, &mut rng)?;
 //! #
-//! # let alexis_my_encrypted_secret_shares = vec![alice_encrypted_shares[0].clone(),
-//! #                                   bob_encrypted_shares[0].clone(),
-//! #                                   carol_encrypted_shares[0].clone()];
-//! # let barbara_my_encrypted_secret_shares = vec![alice_encrypted_shares[1].clone(),
-//! #                                   bob_encrypted_shares[1].clone(),
-//! #                                   carol_encrypted_shares[1].clone()];
-//! # let claire_my_encrypted_secret_shares = vec![alice_encrypted_shares[2].clone(),
-//! #                                   bob_encrypted_shares[2].clone(),
-//! #                                   carol_encrypted_shares[2].clone()];
-//! # let david_my_encrypted_secret_shares = vec![alice_encrypted_shares[3].clone(),
-//! #                                   bob_encrypted_shares[3].clone(),
-//! #                                   carol_encrypted_shares[3].clone()];
+//! # let alexis_my_encrypted_secret_shares = vec![alice_encrypted_shares.get(&alexis.index).unwrap().clone(),
+//! #                                   bob_encrypted_shares.get(&alexis.index).unwrap().clone(),
+//! #                                   carol_encrypted_shares.get(&alexis.index).unwrap().clone()];
+//! # let barbara_my_encrypted_secret_shares = vec![alice_encrypted_shares.get(&barbara.index).unwrap().clone(),
+//! #                                   bob_encrypted_shares.get(&barbara.index).unwrap().clone(),
+//! #                                   carol_encrypted_shares.get(&barbara.index).unwrap().clone()];
+//! # let claire_my_encrypted_secret_shares = vec![alice_encrypted_shares.get(&claire.index).unwrap().clone(),
+//! #                                   bob_encrypted_shares.get(&claire.index).unwrap().clone(),
+//! #                                   carol_encrypted_shares.get(&claire.index).unwrap().clone()];
+//! # let david_my_encrypted_secret_shares = vec![alice_encrypted_shares.get(&david.index).unwrap().clone(),
+//! #                                   bob_encrypted_shares.get(&david.index).unwrap().clone(),
+//! #                                   carol_encrypted_shares.get(&david.index).unwrap().clone()];
 //! #
 //! # let (alexis_state, _) = alexis_state.to_round_two(alexis_my_encrypted_secret_shares, &mut rng)?;
 //! # let (barbara_state, _) = barbara_state.to_round_two(barbara_my_encrypted_secret_shares, &mut rng)?;
@@ -901,15 +901,15 @@
 //! # let (carol_state, participant_lists) = DistributedKeyGeneration::<_, Secp256k1Sha256>::bootstrap(&params, &carol_dh_sk, &carol.index, &carol_coefficients,
 //! #                                                      &participants, &mut rng)?;
 //! # let carol_their_encrypted_secret_shares = carol_state.their_encrypted_secret_shares()?;
-//! # let alice_my_encrypted_secret_shares = vec![alice_their_encrypted_secret_shares[0].clone(),
-//! #                                   bob_their_encrypted_secret_shares[0].clone(),
-//! #                                   carol_their_encrypted_secret_shares[0].clone()];
-//! # let bob_my_encrypted_secret_shares = vec![alice_their_encrypted_secret_shares[1].clone(),
-//! #                                 bob_their_encrypted_secret_shares[1].clone(),
-//! #                                 carol_their_encrypted_secret_shares[1].clone()];
-//! # let carol_my_encrypted_secret_shares = vec![alice_their_encrypted_secret_shares[2].clone(),
-//! #                                   bob_their_encrypted_secret_shares[2].clone(),
-//! #                                   carol_their_encrypted_secret_shares[2].clone()];
+//! # let alice_my_encrypted_secret_shares = vec![alice_their_encrypted_secret_shares.get(&alice.index).unwrap().clone(),
+//! #                                   bob_their_encrypted_secret_shares.get(&alice.index).unwrap().clone(),
+//! #                                   carol_their_encrypted_secret_shares.get(&alice.index).unwrap().clone()];
+//! # let bob_my_encrypted_secret_shares = vec![alice_their_encrypted_secret_shares.get(&bob.index).unwrap().clone(),
+//! #                                 bob_their_encrypted_secret_shares.get(&bob.index).unwrap().clone(),
+//! #                                 carol_their_encrypted_secret_shares.get(&bob.index).unwrap().clone()];
+//! # let carol_my_encrypted_secret_shares = vec![alice_their_encrypted_secret_shares.get(&carol.index).unwrap().clone(),
+//! #                                   bob_their_encrypted_secret_shares.get(&carol.index).unwrap().clone(),
+//! #                                   carol_their_encrypted_secret_shares.get(&carol.index).unwrap().clone()];
 //! #
 //! # let (alice_state, _) = alice_state.to_round_two(alice_my_encrypted_secret_shares, &mut rng)?;
 //! # let (bob_state, _) = bob_state.to_round_two(bob_my_encrypted_secret_shares, &mut rng)?;
@@ -980,15 +980,15 @@
 //! # let (carol_state, participant_lists) = DistributedKeyGeneration::<_, Secp256k1Sha256>::bootstrap(&params, &carol_dh_sk, &carol.index, &carol_coefficients,
 //! #                                                      &participants, &mut rng)?;
 //! # let carol_their_encrypted_secret_shares = carol_state.their_encrypted_secret_shares()?;
-//! # let alice_my_encrypted_secret_shares = vec![alice_their_encrypted_secret_shares[0].clone(),
-//! #                                   bob_their_encrypted_secret_shares[0].clone(),
-//! #                                   carol_their_encrypted_secret_shares[0].clone()];
-//! # let bob_my_encrypted_secret_shares = vec![alice_their_encrypted_secret_shares[1].clone(),
-//! #                                 bob_their_encrypted_secret_shares[1].clone(),
-//! #                                 carol_their_encrypted_secret_shares[1].clone()];
-//! # let carol_my_encrypted_secret_shares = vec![alice_their_encrypted_secret_shares[2].clone(),
-//! #                                   bob_their_encrypted_secret_shares[2].clone(),
-//! #                                   carol_their_encrypted_secret_shares[2].clone()];
+//! # let alice_my_encrypted_secret_shares = vec![alice_their_encrypted_secret_shares.get(&alice.index).unwrap().clone(),
+//! #                                   bob_their_encrypted_secret_shares.get(&alice.index).unwrap().clone(),
+//! #                                   carol_their_encrypted_secret_shares.get(&alice.index).unwrap().clone()];
+//! # let bob_my_encrypted_secret_shares = vec![alice_their_encrypted_secret_shares.get(&bob.index).unwrap().clone(),
+//! #                                 bob_their_encrypted_secret_shares.get(&bob.index).unwrap().clone(),
+//! #                                 carol_their_encrypted_secret_shares.get(&bob.index).unwrap().clone()];
+//! # let carol_my_encrypted_secret_shares = vec![alice_their_encrypted_secret_shares.get(&carol.index).unwrap().clone(),
+//! #                                   bob_their_encrypted_secret_shares.get(&carol.index).unwrap().clone(),
+//! #                                   carol_their_encrypted_secret_shares.get(&carol.index).unwrap().clone()];
 //! #
 //! # let (alice_state, _) = alice_state.to_round_two(alice_my_encrypted_secret_shares, &mut rng)?;
 //! # let (bob_state, _) = bob_state.to_round_two(bob_my_encrypted_secret_shares, &mut rng)?;
@@ -1054,15 +1054,15 @@
 //! # let (carol_state, participant_lists) = DistributedKeyGeneration::<_, Secp256k1Sha256>::bootstrap(&params, &carol_dh_sk, &carol.index, &carol_coefficients,
 //! #                                                      &participants, &mut rng)?;
 //! # let carol_their_encrypted_secret_shares = carol_state.their_encrypted_secret_shares()?;
-//! # let alice_my_encrypted_secret_shares = vec![alice_their_encrypted_secret_shares[0].clone(),
-//! #                                   bob_their_encrypted_secret_shares[0].clone(),
-//! #                                   carol_their_encrypted_secret_shares[0].clone()];
-//! # let bob_my_encrypted_secret_shares = vec![alice_their_encrypted_secret_shares[1].clone(),
-//! #                                 bob_their_encrypted_secret_shares[1].clone(),
-//! #                                 carol_their_encrypted_secret_shares[1].clone()];
-//! # let carol_my_encrypted_secret_shares = vec![alice_their_encrypted_secret_shares[2].clone(),
-//! #                                   bob_their_encrypted_secret_shares[2].clone(),
-//! #                                   carol_their_encrypted_secret_shares[2].clone()];
+//! # let alice_my_encrypted_secret_shares = vec![alice_their_encrypted_secret_shares.get(&alice.index).unwrap().clone(),
+//! #                                   bob_their_encrypted_secret_shares.get(&alice.index).unwrap().clone(),
+//! #                                   carol_their_encrypted_secret_shares.get(&alice.index).unwrap().clone()];
+//! # let bob_my_encrypted_secret_shares = vec![alice_their_encrypted_secret_shares.get(&bob.index).unwrap().clone(),
+//! #                                 bob_their_encrypted_secret_shares.get(&bob.index).unwrap().clone(),
+//! #                                 carol_their_encrypted_secret_shares.get(&bob.index).unwrap().clone()];
+//! # let carol_my_encrypted_secret_shares = vec![alice_their_encrypted_secret_shares.get(&carol.index).unwrap().clone(),
+//! #                                   bob_their_encrypted_secret_shares.get(&carol.index).unwrap().clone(),
+//! #                                   carol_their_encrypted_secret_shares.get(&carol.index).unwrap().clone()];
 //! #
 //! # let (alice_state, _) = alice_state.to_round_two(alice_my_encrypted_secret_shares, &mut rng)?;
 //! # let (bob_state, _) = bob_state.to_round_two(bob_my_encrypted_secret_shares, &mut rng)?;
@@ -1128,15 +1128,15 @@
 //! # let (carol_state, participant_lists) = DistributedKeyGeneration::<_, Secp256k1Sha256>::bootstrap(&params, &carol_dh_sk, &carol.index, &carol_coefficients,
 //! #                                                      &participants, &mut rng)?;
 //! # let carol_their_encrypted_secret_shares = carol_state.their_encrypted_secret_shares()?;
-//! # let alice_my_encrypted_secret_shares = vec![alice_their_encrypted_secret_shares[0].clone(),
-//! #                                   bob_their_encrypted_secret_shares[0].clone(),
-//! #                                   carol_their_encrypted_secret_shares[0].clone()];
-//! # let bob_my_encrypted_secret_shares = vec![alice_their_encrypted_secret_shares[1].clone(),
-//! #                                 bob_their_encrypted_secret_shares[1].clone(),
-//! #                                 carol_their_encrypted_secret_shares[1].clone()];
-//! # let carol_my_encrypted_secret_shares = vec![alice_their_encrypted_secret_shares[2].clone(),
-//! #                                   bob_their_encrypted_secret_shares[2].clone(),
-//! #                                   carol_their_encrypted_secret_shares[2].clone()];
+//! # let alice_my_encrypted_secret_shares = vec![alice_their_encrypted_secret_shares.get(&alice.index).unwrap().clone(),
+//! #                                   bob_their_encrypted_secret_shares.get(&alice.index).unwrap().clone(),
+//! #                                   carol_their_encrypted_secret_shares.get(&alice.index).unwrap().clone()];
+//! # let bob_my_encrypted_secret_shares = vec![alice_their_encrypted_secret_shares.get(&bob.index).unwrap().clone(),
+//! #                                 bob_their_encrypted_secret_shares.get(&bob.index).unwrap().clone(),
+//! #                                 carol_their_encrypted_secret_shares.get(&bob.index).unwrap().clone()];
+//! # let carol_my_encrypted_secret_shares = vec![alice_their_encrypted_secret_shares.get(&carol.index).unwrap().clone(),
+//! #                                   bob_their_encrypted_secret_shares.get(&carol.index).unwrap().clone(),
+//! #                                   carol_their_encrypted_secret_shares.get(&carol.index).unwrap().clone()];
 //! #
 //! # let (alice_state, _) = alice_state.to_round_two(alice_my_encrypted_secret_shares, &mut rng)?;
 //! # let (bob_state, _) = bob_state.to_round_two(bob_my_encrypted_secret_shares, &mut rng)?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1203,11 +1203,11 @@
 //! # ];
 //! #
 //! # let (mut alice_state, alice_complaints) = alice_state.to_round_two(&alice_my_encrypted_secret_shares, &mut rng)?;
-//! # let alice_complaint = alice_complaints[0].clone();
 //! # let (mut carol_state, carol_complaints) = carol_state.to_round_two(&carol_my_encrypted_secret_shares, &mut rng)?;
 //! #
-//! alice_state.blame(&invalid_share, &alice_complaint);
-//! carol_state.blame(&invalid_share, &alice_complaint);
+//! let all_complaints = &[alice_complaints, carol_complaints].concat();
+//! alice_state.blame(&invalid_share, &all_complaints);
+//! carol_state.blame(&invalid_share, &all_complaints);
 //!
 //! // Alice and Carol can now finish correctly their DKG.
 //! let (alice_group_key, alice_secret_key) = alice_state.finish()?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,9 @@
 //! group verifying key, to be used to attest correctness of the generated ICE-FROST signatures, is invariant
 //! when proceeding to individual signing keys resharing to a (possibly) different group of participants.
 //!
+//! **NOTE**: This library assumes that participants can exchange messages on a public communication channel,
+//! with each message being authentified (i.e. digitally signed) by its sender.
+//!
 //! # Usage
 //!
 //! Alice, Bob, and Carol would like to set up a threshold signing scheme where

--- a/src/sign/signature.rs
+++ b/src/sign/signature.rs
@@ -1597,15 +1597,15 @@ mod test {
         let all_complaints = &[p2_complaints, p5_complaints].concat();
 
         let bad_indices =
-            p2_state.blame(&wrong_encrypted_secret_share_from_p4_to_p2, &all_complaints);
+            p2_state.blame(&wrong_encrypted_secret_share_from_p4_to_p2, all_complaints);
         assert!(bad_indices.len() == 1); // both complaints led to the same conclusion
         assert!(bad_indices[0] == 4);
         let bad_indices =
-            p3_state.blame(&wrong_encrypted_secret_share_from_p4_to_p2, &all_complaints);
+            p3_state.blame(&wrong_encrypted_secret_share_from_p4_to_p2, all_complaints);
         assert!(bad_indices.len() == 1); // both complaints led to the same conclusion
         assert!(bad_indices[0] == 4);
         let bad_indices =
-            p5_state.blame(&wrong_encrypted_secret_share_from_p4_to_p2, &all_complaints);
+            p5_state.blame(&wrong_encrypted_secret_share_from_p4_to_p2, all_complaints);
         assert!(bad_indices.len() == 1); // both complaints led to the same conclusion
         assert!(bad_indices[0] == 4);
 

--- a/src/sign/signature.rs
+++ b/src/sign/signature.rs
@@ -791,7 +791,8 @@ mod test {
             participants_states_1[0]
                 .clone()
                 .to_round_two(p1_my_encrypted_secret_shares, rng)
-                .unwrap(),
+                .unwrap()
+                .0,
         );
 
         for i in 2..n1 + 1 {
@@ -807,7 +808,8 @@ mod test {
                 participants_states_1[(i - 1) as usize]
                     .clone()
                     .to_round_two(pi_my_encrypted_secret_shares, rng)
-                    .unwrap(),
+                    .unwrap()
+                    .0,
             );
         }
 
@@ -886,7 +888,8 @@ mod test {
                     signers_states_1[i]
                         .clone()
                         .to_round_two(signers_encrypted_secret_shares[i].clone(), rng)
-                        .unwrap(),
+                        .unwrap()
+                        .0,
                 );
             }
 

--- a/src/sign/signature.rs
+++ b/src/sign/signature.rs
@@ -1594,38 +1594,20 @@ mod test {
             .unwrap();
         assert!(p5_complaints.len() == 1);
 
-        let bad_index = p2_state.blame(
-            &wrong_encrypted_secret_share_from_p4_to_p2,
-            &p2_complaints[0],
-        );
-        assert!(bad_index == 4);
-        let bad_index = p3_state.blame(
-            &wrong_encrypted_secret_share_from_p4_to_p2,
-            &p2_complaints[0],
-        );
-        assert!(bad_index == 4);
-        let bad_index = p5_state.blame(
-            &wrong_encrypted_secret_share_from_p4_to_p2,
-            &p2_complaints[0],
-        );
-        assert!(bad_index == 4);
+        let all_complaints = &[p2_complaints, p5_complaints].concat();
 
-        // Checking the second complaint won't update the states, as we already got rid of p4 who tried to cheat p2 before.
-        let bad_index = p2_state.blame(
-            &wrong_encrypted_secret_share_from_p4_to_p5,
-            &p5_complaints[0],
-        );
-        assert!(bad_index == 4);
-        let bad_index = p3_state.blame(
-            &wrong_encrypted_secret_share_from_p4_to_p5,
-            &p5_complaints[0],
-        );
-        assert!(bad_index == 4);
-        let bad_index = p5_state.blame(
-            &wrong_encrypted_secret_share_from_p4_to_p5,
-            &p5_complaints[0],
-        );
-        assert!(bad_index == 4);
+        let bad_indices =
+            p2_state.blame(&wrong_encrypted_secret_share_from_p4_to_p2, &all_complaints);
+        assert!(bad_indices.len() == 1); // both complaints led to the same conclusion
+        assert!(bad_indices[0] == 4);
+        let bad_indices =
+            p3_state.blame(&wrong_encrypted_secret_share_from_p4_to_p2, &all_complaints);
+        assert!(bad_indices.len() == 1); // both complaints led to the same conclusion
+        assert!(bad_indices[0] == 4);
+        let bad_indices =
+            p5_state.blame(&wrong_encrypted_secret_share_from_p4_to_p2, &all_complaints);
+        assert!(bad_indices.len() == 1); // both complaints led to the same conclusion
+        assert!(bad_indices[0] == 4);
 
         // Everyone can finish the DKG.
         // However, only honest participants will be able to generate

--- a/src/sign/signature.rs
+++ b/src/sign/signature.rs
@@ -757,10 +757,8 @@ mod test {
         }
 
         let mut participants_encrypted_secret_shares: Vec<
-            Vec<EncryptedSecretShare<Secp256k1Sha256>>,
-        > = (0..n1)
-            .map(|_| Vec::with_capacity((n1 - 1) as usize))
-            .collect();
+            BTreeMap<u32, EncryptedSecretShare<Secp256k1Sha256>>,
+        > = (0..n1).map(|_| BTreeMap::new()).collect();
 
         let mut participants_states_1 = Vec::<Dkg<_>>::new();
         let mut participants_states_2 = Vec::<Dkg<_>>::new();
@@ -784,8 +782,12 @@ mod test {
 
         let mut p1_my_encrypted_secret_shares = Vec::<EncryptedSecretShare<Secp256k1Sha256>>::new();
         for j in 0..n1 {
-            p1_my_encrypted_secret_shares
-                .push(participants_encrypted_secret_shares[j as usize][0].clone());
+            p1_my_encrypted_secret_shares.push(
+                participants_encrypted_secret_shares[j as usize]
+                    .get(&1)
+                    .unwrap()
+                    .clone(),
+            );
         }
         participants_states_2.push(
             participants_states_1[0]
@@ -800,7 +802,10 @@ mod test {
                 Vec::<EncryptedSecretShare<Secp256k1Sha256>>::new();
             for j in 0..n1 {
                 pi_my_encrypted_secret_shares.push(
-                    participants_encrypted_secret_shares[j as usize][(i - 1) as usize].clone(),
+                    participants_encrypted_secret_shares[j as usize]
+                        .get(&i)
+                        .unwrap()
+                        .clone(),
                 );
             }
 
@@ -847,8 +852,8 @@ mod test {
 
             let mut dealers = Vec::with_capacity(n1 as usize);
             let mut dealers_encrypted_secret_shares_for_signers: Vec<
-                Vec<EncryptedSecretShare<Secp256k1Sha256>>,
-            > = (0..n1).map(|_| Vec::new()).collect();
+                BTreeMap<u32, EncryptedSecretShare<Secp256k1Sha256>>,
+            > = (0..n1).map(|_| BTreeMap::new()).collect();
 
             for i in 0..n1 as usize {
                 let (dealer_for_signers, dealer_encrypted_shares_for_signers, _participant_lists) =
@@ -878,7 +883,7 @@ mod test {
             for i in 0..n2 as usize {
                 let shares_for_signer = dealers_encrypted_secret_shares_for_signers
                     .iter()
-                    .map(|v| v[i].clone())
+                    .map(|v| v.get(&(i as u32 + 1)).unwrap().clone())
                     .collect::<Vec<EncryptedSecretShare<Secp256k1Sha256>>>();
                 signers_encrypted_secret_shares[i] = shares_for_signer;
             }
@@ -895,8 +900,8 @@ mod test {
 
             let mut signers_secret_keys = Vec::<IndividualSigningKey<Secp256k1Sha256>>::new();
 
-            for signers_state in signers_states_2.iter() {
-                let (_, pi_sk) = signers_state.clone().finish().unwrap();
+            for signers_state in signers_states_2.into_iter() {
+                let (_, pi_sk) = signers_state.finish().unwrap();
                 signers_secret_keys.push(pi_sk);
             }
 
@@ -1536,52 +1541,53 @@ mod test {
         let p5_their_encrypted_secret_shares = p5_state.their_encrypted_secret_shares().unwrap();
 
         let p1_my_encrypted_secret_shares = vec![
-            p1_their_encrypted_secret_shares[0].clone(),
-            p2_their_encrypted_secret_shares[0].clone(),
-            p3_their_encrypted_secret_shares[0].clone(),
-            p4_their_encrypted_secret_shares[0].clone(),
-            p5_their_encrypted_secret_shares[0].clone(),
+            p1_their_encrypted_secret_shares.get(&1).unwrap().clone(),
+            p2_their_encrypted_secret_shares.get(&1).unwrap().clone(),
+            p3_their_encrypted_secret_shares.get(&1).unwrap().clone(),
+            p4_their_encrypted_secret_shares.get(&1).unwrap().clone(),
+            p5_their_encrypted_secret_shares.get(&1).unwrap().clone(),
         ];
 
         // Wrong share inserted here!
         let mut wrong_encrypted_secret_share_from_p1_to_p2 =
-            p1_their_encrypted_secret_shares[1].clone();
+            p1_their_encrypted_secret_shares.get(&2).unwrap().clone();
         wrong_encrypted_secret_share_from_p1_to_p2.nonce = [42; 16];
         let p2_my_encrypted_secret_shares = vec![
             wrong_encrypted_secret_share_from_p1_to_p2.clone(),
-            p2_their_encrypted_secret_shares[1].clone(),
-            p3_their_encrypted_secret_shares[1].clone(),
-            p4_their_encrypted_secret_shares[1].clone(),
-            p5_their_encrypted_secret_shares[1].clone(),
+            p2_their_encrypted_secret_shares.get(&2).unwrap().clone(),
+            p3_their_encrypted_secret_shares.get(&2).unwrap().clone(),
+            p4_their_encrypted_secret_shares.get(&2).unwrap().clone(),
+            p5_their_encrypted_secret_shares.get(&2).unwrap().clone(),
         ];
 
         let p3_my_encrypted_secret_shares = vec![
-            p1_their_encrypted_secret_shares[2].clone(),
-            p2_their_encrypted_secret_shares[2].clone(),
-            p3_their_encrypted_secret_shares[2].clone(),
-            p4_their_encrypted_secret_shares[2].clone(),
-            p5_their_encrypted_secret_shares[2].clone(),
+            p1_their_encrypted_secret_shares.get(&3).unwrap().clone(),
+            p2_their_encrypted_secret_shares.get(&3).unwrap().clone(),
+            p3_their_encrypted_secret_shares.get(&3).unwrap().clone(),
+            p4_their_encrypted_secret_shares.get(&3).unwrap().clone(),
+            p5_their_encrypted_secret_shares.get(&3).unwrap().clone(),
         ];
         let p4_my_encrypted_secret_shares = vec![
-            p1_their_encrypted_secret_shares[3].clone(),
-            p2_their_encrypted_secret_shares[3].clone(),
-            p3_their_encrypted_secret_shares[3].clone(),
-            p4_their_encrypted_secret_shares[3].clone(),
-            p5_their_encrypted_secret_shares[3].clone(),
+            p1_their_encrypted_secret_shares.get(&4).unwrap().clone(),
+            p2_their_encrypted_secret_shares.get(&4).unwrap().clone(),
+            p3_their_encrypted_secret_shares.get(&4).unwrap().clone(),
+            p4_their_encrypted_secret_shares.get(&4).unwrap().clone(),
+            p5_their_encrypted_secret_shares.get(&4).unwrap().clone(),
         ];
 
         // Wrong shares inserted here!
         let mut wrong_encrypted_secret_share_from_p1_to_p5 =
-            p1_their_encrypted_secret_shares[4].clone();
+            p1_their_encrypted_secret_shares.get(&5).unwrap().clone();
         wrong_encrypted_secret_share_from_p1_to_p5.nonce = [42; 16];
-        let mut wrong_encrypted_secret_share_from_p4 = p4_their_encrypted_secret_shares[4].clone();
+        let mut wrong_encrypted_secret_share_from_p4 =
+            p4_their_encrypted_secret_shares.get(&5).unwrap().clone();
         wrong_encrypted_secret_share_from_p4.nonce = [42; 16];
         let p5_my_encrypted_secret_shares = vec![
             wrong_encrypted_secret_share_from_p1_to_p5.clone(),
-            p2_their_encrypted_secret_shares[4].clone(),
-            p3_their_encrypted_secret_shares[4].clone(),
+            p2_their_encrypted_secret_shares.get(&5).unwrap().clone(),
+            p3_their_encrypted_secret_shares.get(&5).unwrap().clone(),
             wrong_encrypted_secret_share_from_p4.clone(),
-            p5_their_encrypted_secret_shares[4].clone(),
+            p5_their_encrypted_secret_shares.get(&5).unwrap().clone(),
         ];
 
         let (p1_state, complaints) = p1_state

--- a/src/sign/signature.rs
+++ b/src/sign/signature.rs
@@ -880,12 +880,12 @@ mod test {
                 signers_states_1.push(signer_state);
             }
 
-            for i in 0..n2 as usize {
+            for (i, shares) in signers_encrypted_secret_shares.iter_mut().enumerate() {
                 let shares_for_signer = dealers_encrypted_secret_shares_for_signers
                     .iter()
                     .map(|v| v.get(&(i as u32 + 1)).unwrap().clone())
                     .collect::<Vec<EncryptedSecretShare<Secp256k1Sha256>>>();
-                signers_encrypted_secret_shares[i] = shares_for_signer;
+                *shares = shares_for_signer;
             }
 
             for i in 0..n2 as usize {

--- a/tests/ice_frost.rs
+++ b/tests/ice_frost.rs
@@ -49,43 +49,143 @@ fn signing_and_verification_3_out_of_5() {
     let p5_their_encrypted_secret_shares = p5_state.their_encrypted_secret_shares().unwrap();
 
     let p1_my_encrypted_secret_shares = vec![
-        p1_their_encrypted_secret_shares[0].clone(),
-        p2_their_encrypted_secret_shares[0].clone(),
-        p3_their_encrypted_secret_shares[0].clone(),
-        p4_their_encrypted_secret_shares[0].clone(),
-        p5_their_encrypted_secret_shares[0].clone(),
+        p1_their_encrypted_secret_shares
+            .get(&1)
+            .unwrap()
+            .clone()
+            .clone(),
+        p2_their_encrypted_secret_shares
+            .get(&1)
+            .unwrap()
+            .clone()
+            .clone(),
+        p3_their_encrypted_secret_shares
+            .get(&1)
+            .unwrap()
+            .clone()
+            .clone(),
+        p4_their_encrypted_secret_shares
+            .get(&1)
+            .unwrap()
+            .clone()
+            .clone(),
+        p5_their_encrypted_secret_shares
+            .get(&1)
+            .unwrap()
+            .clone()
+            .clone(),
     ];
 
     let p2_my_encrypted_secret_shares = vec![
-        p1_their_encrypted_secret_shares[1].clone(),
-        p2_their_encrypted_secret_shares[1].clone(),
-        p3_their_encrypted_secret_shares[1].clone(),
-        p4_their_encrypted_secret_shares[1].clone(),
-        p5_their_encrypted_secret_shares[1].clone(),
+        p1_their_encrypted_secret_shares
+            .get(&2)
+            .unwrap()
+            .clone()
+            .clone(),
+        p2_their_encrypted_secret_shares
+            .get(&2)
+            .unwrap()
+            .clone()
+            .clone(),
+        p3_their_encrypted_secret_shares
+            .get(&2)
+            .unwrap()
+            .clone()
+            .clone(),
+        p4_their_encrypted_secret_shares
+            .get(&2)
+            .unwrap()
+            .clone()
+            .clone(),
+        p5_their_encrypted_secret_shares
+            .get(&2)
+            .unwrap()
+            .clone()
+            .clone(),
     ];
 
     let p3_my_encrypted_secret_shares = vec![
-        p1_their_encrypted_secret_shares[2].clone(),
-        p2_their_encrypted_secret_shares[2].clone(),
-        p3_their_encrypted_secret_shares[2].clone(),
-        p4_their_encrypted_secret_shares[2].clone(),
-        p5_their_encrypted_secret_shares[2].clone(),
+        p1_their_encrypted_secret_shares
+            .get(&3)
+            .unwrap()
+            .clone()
+            .clone(),
+        p2_their_encrypted_secret_shares
+            .get(&3)
+            .unwrap()
+            .clone()
+            .clone(),
+        p3_their_encrypted_secret_shares
+            .get(&3)
+            .unwrap()
+            .clone()
+            .clone(),
+        p4_their_encrypted_secret_shares
+            .get(&3)
+            .unwrap()
+            .clone()
+            .clone(),
+        p5_their_encrypted_secret_shares
+            .get(&3)
+            .unwrap()
+            .clone()
+            .clone(),
     ];
 
     let p4_my_encrypted_secret_shares = vec![
-        p1_their_encrypted_secret_shares[3].clone(),
-        p2_their_encrypted_secret_shares[3].clone(),
-        p3_their_encrypted_secret_shares[3].clone(),
-        p4_their_encrypted_secret_shares[3].clone(),
-        p5_their_encrypted_secret_shares[3].clone(),
+        p1_their_encrypted_secret_shares
+            .get(&4)
+            .unwrap()
+            .clone()
+            .clone(),
+        p2_their_encrypted_secret_shares
+            .get(&4)
+            .unwrap()
+            .clone()
+            .clone(),
+        p3_their_encrypted_secret_shares
+            .get(&4)
+            .unwrap()
+            .clone()
+            .clone(),
+        p4_their_encrypted_secret_shares
+            .get(&4)
+            .unwrap()
+            .clone()
+            .clone(),
+        p5_their_encrypted_secret_shares
+            .get(&4)
+            .unwrap()
+            .clone()
+            .clone(),
     ];
 
     let p5_my_encrypted_secret_shares = vec![
-        p1_their_encrypted_secret_shares[4].clone(),
-        p2_their_encrypted_secret_shares[4].clone(),
-        p3_their_encrypted_secret_shares[4].clone(),
-        p4_their_encrypted_secret_shares[4].clone(),
-        p5_their_encrypted_secret_shares[4].clone(),
+        p1_their_encrypted_secret_shares
+            .get(&5)
+            .unwrap()
+            .clone()
+            .clone(),
+        p2_their_encrypted_secret_shares
+            .get(&5)
+            .unwrap()
+            .clone()
+            .clone(),
+        p3_their_encrypted_secret_shares
+            .get(&5)
+            .unwrap()
+            .clone()
+            .clone(),
+        p4_their_encrypted_secret_shares
+            .get(&5)
+            .unwrap()
+            .clone()
+            .clone(),
+        p5_their_encrypted_secret_shares
+            .get(&5)
+            .unwrap()
+            .clone()
+            .clone(),
     ];
 
     let (p1_state, complaints) = p1_state

--- a/tests/ice_frost.rs
+++ b/tests/ice_frost.rs
@@ -88,21 +88,26 @@ fn signing_and_verification_3_out_of_5() {
         p5_their_encrypted_secret_shares[4].clone(),
     ];
 
-    let p1_state = p1_state
+    let (p1_state, complaints) = p1_state
         .to_round_two(p1_my_encrypted_secret_shares, rng)
         .unwrap();
-    let p2_state = p2_state
+    assert!(complaints.is_empty());
+    let (p2_state, complaints) = p2_state
         .to_round_two(p2_my_encrypted_secret_shares, rng)
         .unwrap();
-    let p3_state = p3_state
+    assert!(complaints.is_empty());
+    let (p3_state, complaints) = p3_state
         .to_round_two(p3_my_encrypted_secret_shares, rng)
         .unwrap();
-    let p4_state = p4_state
+    assert!(complaints.is_empty());
+    let (p4_state, complaints) = p4_state
         .to_round_two(p4_my_encrypted_secret_shares, rng)
         .unwrap();
-    let p5_state = p5_state
+    assert!(complaints.is_empty());
+    let (p5_state, complaints) = p5_state
         .to_round_two(p5_my_encrypted_secret_shares, rng)
         .unwrap();
+    assert!(complaints.is_empty());
 
     let (group_key, p1_sk) = p1_state.finish().unwrap();
     let (_, _) = p2_state.finish().unwrap();


### PR DESCRIPTION
# Description

This fixes the behavior of the DKG which currently:
- fails during round 2 if we are missing shares -> this should not be the case, because we will not include shares from malicious participants detected in round 1
- fails at generating valid individual key pairs at the end of the DKG when there are malicious participants in round 2 -> this is because we should prune those from the list of participants when proceeding to `finish`. This wasn't caught before because we never tested the signature phase with an incomplete list of participants.

## Additions and Changes

Fixes both logic above.
Because the ordering may be inconsistent in case of invalid participants removal between rounds, most `Vec` in the `ActualState` struct are replaced with maps to link participant indices to their associated data. This should remove ambiguity and risk of misuse when sharing data to specific individuals, or when handling participant removal.

I will also add an extensive section in the documentation about malicious participant handling, complaints and blaming.

## PR Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added or updated tests that comprehensively prove my change is effective or that my feature works
