### PR TITLE
Cleanup and apply latest clippy

### DIFF
--- a/src/dkg/key_generation.rs
+++ b/src/dkg/key_generation.rs
@@ -2493,17 +2493,17 @@ mod test {
 
             // Wrong complaint leads to blaming the complaint maker
             {
-                let _p1_my_encrypted_secret_shares = vec![
+                let _p1_my_encrypted_secret_shares = [
                     p1_their_encrypted_secret_shares.get(&1).unwrap().clone(),
                     p2_their_encrypted_secret_shares.get(&1).unwrap().clone(),
                     p3_their_encrypted_secret_shares.get(&1).unwrap().clone(),
                 ];
-                let _p2_my_encrypted_secret_shares = vec![
+                let _p2_my_encrypted_secret_shares = [
                     p1_their_encrypted_secret_shares.get(&1).unwrap().clone(),
                     p2_their_encrypted_secret_shares.get(&2).unwrap().clone(),
                     p3_their_encrypted_secret_shares.get(&2).unwrap().clone(),
                 ];
-                let p3_my_encrypted_secret_shares = vec![
+                let p3_my_encrypted_secret_shares = [
                     p1_their_encrypted_secret_shares.get(&3).unwrap().clone(),
                     p2_their_encrypted_secret_shares.get(&3).unwrap().clone(),
                     p3_their_encrypted_secret_shares.get(&3).unwrap().clone(),

--- a/src/dkg/round_types.rs
+++ b/src/dkg/round_types.rs
@@ -37,22 +37,3 @@ pub trait DkgState: private::Sealed + CanonicalDeserialize + CanonicalSerialize 
 
 impl DkgState for RoundOne {}
 impl DkgState for RoundTwo {}
-
-/// Marker trait to designate valid variants of [`RoundOne`] in the distributed
-/// key generation protocol's state machine.  It is implemented using the
-/// [sealed trait design pattern][sealed] pattern to prevent external types from
-/// implementing further valid states.
-///
-/// [sealed]: https://rust-lang.github.io/api-guidelines/future-proofing.html#sealed-traits-protect-against-downstream-implementations-c-sealed
-pub trait Round1: private::Sealed {}
-
-/// Marker trait to designate valid variants of [`RoundTwo`] in the distributed
-/// key generation protocol's state machine.  It is implemented using the
-/// [sealed trait design pattern][sealed] pattern to prevent external types from
-/// implementing further valid states.
-///
-/// [sealed]: https://rust-lang.github.io/api-guidelines/future-proofing.html#sealed-traits-protect-against-downstream-implementations-c-sealed
-pub trait Round2: private::Sealed {}
-
-impl Round1 for RoundOne {}
-impl Round2 for RoundTwo {}

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -8,7 +8,7 @@ pub use alloc::{
     boxed::Box,
     collections::btree_map::BTreeMap,
     string::{String, ToString},
-    vec::{self, Vec},
+    vec::Vec,
 };
 
 #[cfg(feature = "std")]


### PR DESCRIPTION
# Description

Latest clippy is notifying of some additional lints.
Also noticed the `Round1` / `Round2` traits were not necessary as we already implement `sealed` for `RoundOne` and `RoundTwo`.

Fixes # (issue)

## Additions and Changes

Please explain in detail, if applicable, which changes you performed in the PR and link them to issues. (If not applicable you can remove this whole section)

### Bug fix (non-breaking change which fixes an issue)

### New feature (non-breaking change which adds functionality)

## Breaking changes

Please explain in detail which changes are breaking changes in the PR. (If not applicable you can remove this whole section)

## PR Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added or updated tests that comprehensively prove my change is effective or that my feature works
