### PR TITLE
Fix clippy with latest nightly

### DIFF
--- a/src/ciphersuite.rs
+++ b/src/ciphersuite.rs
@@ -1,6 +1,7 @@
 //! The ciphersuite module to parameterize ICE-FROST sessions.
 
 use core::fmt::Debug;
+#[cfg(not(feature = "std"))]
 use core::marker::{Send, Sync};
 
 use aead::{Aead, KeyInit};

--- a/src/dkg/key_generation.rs
+++ b/src/dkg/key_generation.rs
@@ -1185,15 +1185,11 @@ impl<C: CipherSuite> DistributedKeyGeneration<RoundTwo, C> {
 
 #[cfg(test)]
 mod test {
-    use core::ops::Mul;
-
     use super::*;
     use crate::dkg::{ComplaintProof, NizkPokOfSecretKey};
     use crate::keys::IndividualVerifyingKey;
     use crate::testing::Secp256k1Sha256;
-    use crate::{FromBytes, ToBytes};
 
-    use ark_ec::Group;
     use ark_ff::UniformRand;
     use ark_secp256k1::{Fr, Projective};
 

--- a/src/dkg/nizkpok.rs
+++ b/src/dkg/nizkpok.rs
@@ -95,7 +95,6 @@ mod test {
     use super::*;
     use crate::testing::Secp256k1Sha256;
 
-    use ark_ec::Group;
     use ark_secp256k1::{Fr, Projective};
     use core::ops::Mul;
     use rand::{rngs::OsRng, RngCore};

--- a/src/dkg/secret_share.rs
+++ b/src/dkg/secret_share.rs
@@ -370,7 +370,7 @@ mod test {
 
     use ark_ff::UniformRand;
     use ark_secp256k1::Fr;
-    use rand::{rngs::OsRng, RngCore};
+    use rand::rngs::OsRng;
 
     #[test]
     fn test_serialization() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1588,7 +1588,7 @@
 //! let verified = threshold_signature.verify(alice_group_key, &message_hash)?;
 //! ```
 
-#![cfg_attr(not(feature = "std"), no_std)]
+#![no_std]
 #![cfg_attr(docsrs, feature(doc_cfg))]
 #![deny(rustdoc::broken_intra_doc_links)]
 #![deny(missing_debug_implementations)]
@@ -1597,7 +1597,7 @@
 #![warn(future_incompatible)]
 #![allow(clippy::type_complexity)]
 
-#[cfg(any(test, feature = "std"))]
+#[cfg(feature = "std")]
 #[macro_use]
 extern crate std;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1597,7 +1597,7 @@
 #![warn(future_incompatible)]
 #![allow(clippy::type_complexity)]
 
-#[cfg(feature = "std")]
+#[cfg(any(test, feature = "std"))]
 #[macro_use]
 extern crate std;
 

--- a/src/sign/precomputation.rs
+++ b/src/sign/precomputation.rs
@@ -232,12 +232,9 @@ mod test {
     use super::*;
     use crate::testing::Secp256k1Sha256;
 
-    use ark_ec::{CurveGroup, Group};
     use ark_ff::UniformRand;
     use ark_secp256k1::{Fr, Projective};
     use rand::rngs::OsRng;
-
-    use core::ops::Mul;
 
     #[test]
     fn secret_pair() {

--- a/src/sign/signature.rs
+++ b/src/sign/signature.rs
@@ -715,7 +715,7 @@ mod test {
 
     use ark_secp256k1::{Fr, Projective};
 
-    use ark_ff::{UniformRand, Zero};
+    use ark_ff::UniformRand;
     use rand::rngs::OsRng;
 
     fn do_keygen(


### PR DESCRIPTION
# Description

Latest versions of the compiler broke clippy runs by warning about redundant imports, cf:

```bash
error: the item `String` is imported redundantly
    --> src/lib.rs:1640:17
     |
1640 |     use utils::{String, ToOwned};
     |                 ^^^^^^
     |
    ::: /Users/nashtare/.rustup/toolchains/nightly-aarch64-apple-darwin/lib/rustlib/src/rust/library/std/src/prelude/mod.rs:125:13
     |
125  |     pub use super::v1::*;
     |             --------- the item `String` is already defined here
```

To alleviate this, we fully exclude the use of the `std` prelude by marking the library as `#![no_std]`, and then import `std` conditionally through `extern crate std;`.
Additionally, some _actual_ redundant imports were not caught previously and have been cleaned up altogether.