### PR TITLE
Make tests run in no-std as well

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,27 @@ jobs:
           command: test
           args: --verbose --release --all
 
+  test_no_std:
+    name: Test on ${{ matrix.os }} (no-std)
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        toolchain: [stable]
+        os: [ubuntu-latest]
+
+    steps:
+      - uses: actions/checkout@main
+      - name: Install rust
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: ${{matrix.toolchain}}
+          override: true
+      - name: Run tests
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --verbose --release --all --no-default-features
+
   build:
     name: Build target ${{ matrix.target }}
     runs-on: ${{ matrix.os }}

--- a/src/ciphersuite.rs
+++ b/src/ciphersuite.rs
@@ -1,8 +1,6 @@
 //! The ciphersuite module to parameterize ICE-FROST sessions.
 
 use core::fmt::Debug;
-#[cfg(not(feature = "std"))]
-use core::marker::{Send, Sync};
 
 use aead::{Aead, KeyInit};
 use zeroize::Zeroize;

--- a/src/dkg/secret_share.rs
+++ b/src/dkg/secret_share.rs
@@ -13,9 +13,6 @@ use crate::serialization::impl_serialization_traits;
 use crate::utils::{Scalar, ToString, Vec};
 use crate::{Error, FrostResult};
 
-#[cfg(not(feature = "std"))]
-use alloc::vec;
-
 use crate::ciphersuite::CipherSuite;
 
 use ark_ec::{CurveGroup, Group};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1597,11 +1597,12 @@
 #![warn(future_incompatible)]
 #![allow(clippy::type_complexity)]
 
-#[cfg(any(test, feature = "std"))]
+#[cfg(feature = "std")]
 #[macro_use]
 extern crate std;
 
 #[cfg(not(feature = "std"))]
+#[macro_use]
 extern crate alloc;
 
 pub(crate) const HASH_SEC_PARAM: usize = 128;

--- a/src/sign/signature.rs
+++ b/src/sign/signature.rs
@@ -1129,8 +1129,6 @@ mod test {
         let threshold_signature = signing_result.unwrap();
         let verification_result = threshold_signature.verify(&group_key, &message_hash);
 
-        println!("{:?}", verification_result);
-
         assert!(verification_result.is_ok());
     }
 
@@ -1189,7 +1187,7 @@ mod test {
             let threshold_signature = signing_result.unwrap();
             let verification_result = threshold_signature.verify(&group_key, &message_hash);
 
-            println!("Dealer's signing session: {:?}", verification_result);
+            assert!(verification_result.is_ok());
 
             let message = b"This is a test of the tsunami alert system. This is only a test.";
             let (s1_public_comshares, mut s1_secret_comshares) =
@@ -1234,8 +1232,6 @@ mod test {
 
             let threshold_signature = signing_result.unwrap();
             let verification_result = threshold_signature.verify(&group_key, &message_hash);
-
-            println!("Signers's signing session: {:?}", verification_result);
 
             assert!(verification_result.is_ok());
         } else {
@@ -1304,7 +1300,7 @@ mod test {
             let threshold_signature = signing_result.unwrap();
             let verification_result = threshold_signature.verify(&group_key, &message_hash);
 
-            println!("Dealer's signing session: {:?}", verification_result);
+            assert!(verification_result.is_ok());
 
             let message = b"This is a test of the tsunami alert system. This is only a test.";
             let (s1_public_comshares, mut s1_secret_comshares) =
@@ -1362,8 +1358,6 @@ mod test {
 
             let threshold_signature = signing_result.unwrap();
             let verification_result = threshold_signature.verify(&group_key, &message_hash);
-
-            println!("Signers's signing session: {:?}", verification_result);
 
             assert!(verification_result.is_ok());
         } else {


### PR DESCRIPTION
# Description

Make tests compatible with no-std so that we can assert further the library in such contexts.
Also adds a new CI job for testing with `--no-default-features` flag.

Currently based off #32 