### PR TITLE
Update coverage workflow's toolchain

### DIFF
--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -11,16 +11,25 @@ jobs:
   codecov:
     name: Code coverage
     runs-on: ubuntu-latest
-    container:
-      # See https://github.com/xd009642/tarpaulin/issues/1282 for usage of older nightly revision
-      image: xd009642/tarpaulin:develop-nightly-2024-02-1
-      options: --security-opt seccomp=unconfined
-
+    timeout-minutes: 30
+    if: "! contains(toJSON(github.event.commits.*.message), '[skip-ci]')"
     steps:
-      - uses: actions/checkout@v3
+      - name: Checkout sources
+        uses: actions/checkout@v4
 
-      - run: |
-          cargo tarpaulin --verbose --engine llvm --release --out Xml
+      - name: Install nightly toolchain
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: nightly-2024-02-01
+          components: tarpaulin
+
+      - name: Set up rust cache
+        uses: Swatinem/rust-cache@v2
+        with:
+            cache-on-failure: true
+
+      - name: Run cargo fmt
+        run: cargo tarpaulin --verbose --engine llvm --release --out Xml
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v3.1.1

--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -12,7 +12,8 @@ jobs:
     name: Code coverage
     runs-on: ubuntu-latest
     container:
-      image: xd009642/tarpaulin:develop-nightly
+      # See https://github.com/xd009642/tarpaulin/issues/1282 for usage of older nightly revision
+      image: xd009642/tarpaulin:develop-nightly-2024-02-1
       options: --security-opt seccomp=unconfined
 
     steps:


### PR DESCRIPTION
# Description

cf https://github.com/xd009642/tarpaulin/issues/1282
Attempts at pinning to an older nightly version for the code coverage workflow, as a temporary workaround.
