### PR TITLE
Add test case for resharing from outside of FROST

### DIFF
--- a/src/dkg/key_generation.rs
+++ b/src/dkg/key_generation.rs
@@ -666,8 +666,9 @@ impl<C: CipherSuite> DistributedKeyGeneration<RoundOne, C> {
     ///
     /// # Inputs
     ///
-    /// * The protocol new instance [`ThresholdParameters`]. These parameters can
-    ///   be different from the previous ICE-FROST session using the same group key.
+    /// * The protocol old instance [`ThresholdParameters`]. These parameters can
+    ///   be different from the current ICE-FROST session which will be having the
+    ///   same group key.
     /// * This participant's [`DiffieHellmanPrivateKey`].
     /// * This participant's `index`.
     /// * The list of `dealers`. These are the participants of the previous ICE-FROST

--- a/src/keys.rs
+++ b/src/keys.rs
@@ -200,7 +200,15 @@ impl<C: CipherSuite> Drop for IndividualSigningKey<C> {
 }
 
 impl<C: CipherSuite> IndividualSigningKey<C> {
-    /// Derive the corresponding public key for this secret key.
+    /// Outputs an [`IndividualSigningKey`] from an isolated secret key.
+    /// This can be useful for single parties owning a public key for
+    /// Schnorr signatures outside of an ICE-FROST context and who would
+    /// like to reshare its corresponding secret key to a set of participants.
+    pub fn from_single_key(key: <C::G as Group>::ScalarField) -> Self {
+        Self { index: 1, key }
+    }
+
+    /// Derives the corresponding public key for this secret key.
     pub fn to_public(&self) -> IndividualVerifyingKey<C> {
         let share = C::G::generator() * self.key;
 

--- a/src/sign/signature.rs
+++ b/src/sign/signature.rs
@@ -476,6 +476,8 @@ impl<C: CipherSuite> SignatureAggregator<C, Initial<'_>> {
     }
 
     /// Get the list of partipating signers.
+    /// It will internally sort the signers by indices, remove any duplicate,
+    /// and then return a reference to the updated internal list.
     ///
     /// # Returns
     ///
@@ -556,7 +558,7 @@ impl<C: CipherSuite> SignatureAggregator<C, Initial<'_>> {
         }
 
         // Ensure that our new state is ordered and deduplicated.
-        self.state.signers = self.get_signers().clone();
+        let _ = self.get_signers();
 
         for signer in &self.state.signers {
             if self

--- a/tests/ice_frost.rs
+++ b/tests/ice_frost.rs
@@ -1,10 +1,13 @@
 //! Integration tests for ICE-FROST.
 
+use ark_ec::Group;
+use ark_ff::UniformRand;
+use ice_frost::keys::{DiffieHellmanPrivateKey, GroupVerifyingKey, IndividualSigningKey};
 use rand::rngs::OsRng;
 
 use ice_frost::CipherSuite;
 
-use ice_frost::dkg::{DistributedKeyGeneration, Participant};
+use ice_frost::dkg::{DistributedKeyGeneration, EncryptedSecretShare, Participant, RoundOne};
 use ice_frost::parameters::ThresholdParameters;
 use ice_frost::sign::generate_commitment_share_lists;
 
@@ -271,4 +274,87 @@ fn signing_and_verification_3_out_of_5() {
 
     assert!(verification_result1.is_ok());
     assert!(verification_result2.is_ok());
+}
+
+#[test]
+fn resharing_from_non_frost_key() {
+    type SchnorrSecretKey = <<Secp256k1Sha256 as CipherSuite>::G as Group>::ScalarField;
+    type SchnorrPublicKey = <Secp256k1Sha256 as CipherSuite>::G;
+
+    // A single party outside of any ICE-FROST scenario, who owns a keypair to perform
+    // Schnorr signatures.
+    let mut rng = OsRng;
+    let single_party_sk: SchnorrSecretKey = SchnorrSecretKey::rand(&mut rng);
+    let single_party_pk: SchnorrPublicKey =
+        <<Secp256k1Sha256 as CipherSuite>::G>::generator() * single_party_sk;
+
+    // Converts this party's keys into ICE-FROST format, simulating a 1-out-of-1 setup.
+    let simulated_parameters = ThresholdParameters::new(1, 1);
+    let frost_sk = IndividualSigningKey::from_single_key(single_party_sk);
+    let frost_pk = GroupVerifyingKey::new(single_party_pk);
+
+    // Start a resharing phase from this single party to a set of new participants.
+    const N_PARAM: u32 = 5;
+    const T_PARAM: u32 = 3;
+
+    let threshold_parameters = ThresholdParameters::new(N_PARAM, T_PARAM);
+
+    let mut signers = Vec::<Participant<Secp256k1Sha256>>::new();
+    let mut signers_dh_secret_keys = Vec::<DiffieHellmanPrivateKey<Secp256k1Sha256>>::new();
+
+    for i in 1..=N_PARAM {
+        let (p, dh_sk) =
+            Participant::<Secp256k1Sha256>::new_signer(threshold_parameters, i, rng).unwrap();
+
+        signers.push(p);
+        signers_dh_secret_keys.push(dh_sk);
+    }
+
+    let mut signers_encrypted_secret_shares: Vec<Vec<EncryptedSecretShare<Secp256k1Sha256>>> =
+        (0..N_PARAM).map(|_| Vec::new()).collect();
+
+    let mut signers_states_1 = Vec::<Dkg<_>>::new();
+    let mut signers_states_2 = Vec::<Dkg<_>>::new();
+
+    let (single_dealer, dealer_encrypted_shares_for_signers, _participant_lists) =
+        Participant::reshare(threshold_parameters, &frost_sk, &signers, rng).unwrap();
+
+    for i in 0..N_PARAM as usize {
+        let (signer_state, _participant_lists) =
+            DistributedKeyGeneration::<RoundOne, Secp256k1Sha256>::new(
+                simulated_parameters,
+                &signers_dh_secret_keys[i],
+                signers[i].index,
+                &[single_dealer.clone()],
+                rng,
+            )
+            .unwrap();
+        signers_states_1.push(signer_state);
+    }
+
+    for (i, shares) in signers_encrypted_secret_shares.iter_mut().enumerate() {
+        let share_for_signer = dealer_encrypted_shares_for_signers
+            .get(&(i as u32 + 1))
+            .unwrap()
+            .clone();
+        *shares = vec![share_for_signer];
+    }
+
+    for i in 0..N_PARAM as usize {
+        let (si_state, complaints) = signers_states_1[i]
+            .clone()
+            .to_round_two(&signers_encrypted_secret_shares[i], rng)
+            .unwrap();
+        assert!(complaints.is_empty());
+
+        signers_states_2.push(si_state);
+    }
+
+    for signers_state in &signers_states_2 {
+        let (si_group_key, _si_sk) = signers_state.clone().finish().unwrap();
+
+        // Assert that each signer's individual group key matches the converted
+        // single's party public key.
+        assert!(si_group_key == frost_pk);
+    }
 }


### PR DESCRIPTION
# Description

This PR adds an integration test for key resharing from an initial, single party that didn't take part in any ICE-FROST key generation process, but who owns a valid keypair for Schnorr signatures.
The resulting individuals' group keys (from the new set) are checked to match the initial public key belonging to the initial party.

This requires an API change to create an `IndividualSigningKey` from an isolated secret key (i.e. without any DKG indexing).
