### PR TITLE
No side-effects in getters

### DIFF
--- a/benches/sign.rs
+++ b/benches/sign.rs
@@ -165,7 +165,7 @@ fn criterion_benchmark(c: &mut Criterion) {
     }
 
     let signers = aggregator.get_signers().clone();
-    let message_hash = Secp256k1Sha256::h4(&message[..]);
+    let message_hash = Secp25dedup_signersh4(&message[..]);
     let message_hash_copy = message_hash;
 
     let p1_sk = participants_secret_keys[0].clone();

--- a/benches/sign.rs
+++ b/benches/sign.rs
@@ -164,8 +164,8 @@ fn criterion_benchmark(c: &mut Criterion) {
         );
     }
 
-    let signers = aggregator.get_signers().clone();
-    let message_hash = Secp25dedup_signersh4(&message[..]);
+    let signers = aggregator.signers().to_vec();
+    let message_hash = Secp256k1Sha256::h4(&message[..]);
     let message_hash_copy = message_hash;
 
     let p1_sk = participants_secret_keys[0].clone();

--- a/benches/sign.rs
+++ b/benches/sign.rs
@@ -157,11 +157,13 @@ fn criterion_benchmark(c: &mut Criterion) {
     let mut aggregator = SignatureAggregator::new(params, group_key, &message[..]);
 
     for i in 1..THRESHOLD_OF_PARTICIPANTS + 1 {
-        aggregator.include_signer(
-            i,
-            participants_public_comshares[(i - 1) as usize].commitments[0],
-            &participants_secret_keys[(i - 1) as usize].to_public(),
-        );
+        aggregator
+            .include_signer(
+                i,
+                participants_public_comshares[(i - 1) as usize].commitments[0],
+                &participants_secret_keys[(i - 1) as usize].to_public(),
+            )
+            .unwrap();
     }
 
     let signers = aggregator.signers().to_vec();

--- a/src/error.rs
+++ b/src/error.rs
@@ -27,6 +27,8 @@ pub enum Error<C: CipherSuite> {
     ComplaintVerificationError,
     /// The index of a participant is zero
     IndexIsZero,
+    /// The index of a signer does not match the index in the public key
+    IndexMismatch(u32, u32),
     /// GroupVerifyingKey generation failure
     InvalidGroupKey,
     /// Invalid NiZK proof of knowledge
@@ -87,7 +89,14 @@ impl<C: CipherSuite> core::fmt::Display for Error<C> {
                 write!(f, "The complaint is not correct.")
             }
             Error::IndexIsZero => {
-                write!(f, "The indexs of a participant cannot be 0.")
+                write!(f, "The index of a participant cannot be 0.")
+            }
+            Error::IndexMismatch(participant_idx, pubkey_idx) => {
+                write!(
+                    f,
+                    "Index mismatch between participant index ({}) and the publick key index ({}).",
+                    participant_idx, pubkey_idx
+                )
             }
             Error::InvalidGroupKey => {
                 write!(

--- a/src/error.rs
+++ b/src/error.rs
@@ -94,7 +94,7 @@ impl<C: CipherSuite> core::fmt::Display for Error<C> {
             Error::IndexMismatch(participant_idx, pubkey_idx) => {
                 write!(
                     f,
-                    "Index mismatch between participant index ({}) and the publick key index ({}).",
+                    "Index mismatch between participant index ({}) and the public key index ({}).",
                     participant_idx, pubkey_idx
                 )
             }

--- a/src/error.rs
+++ b/src/error.rs
@@ -47,6 +47,8 @@ pub enum Error<C: CipherSuite> {
     InvalidMSMParameters,
     /// Too many invalid participants, with their indices
     TooManyInvalidParticipants(Vec<u32>),
+    /// Too many unique signers given the [`crate::parameters::ThresholdParameters`].
+    TooManySigners(usize, u32),
     /// The participant is missing commitment shares
     MissingCommitmentShares,
     /// Invalid binding factor
@@ -143,6 +145,13 @@ impl<C: CipherSuite> core::fmt::Display for Error<C> {
                     f,
                     "Too many invalid participants to continue the Dkg: {:?}",
                     indices
+                )
+            }
+            Error::TooManySigners(signers, n_param) => {
+                write!(
+                    f,
+                    "Too many signers ({}) given the DKG instance parameters ({}).",
+                    signers, n_param
                 )
             }
             Error::MissingCommitmentShares => {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1455,7 +1455,7 @@
 //! #
 //! # aggregator.include_signer(1, alice_public_comshares.commitments[0], &alice_public_key);
 //! # aggregator.include_signer(3, carol_public_comshares.commitments[0], &carol_public_key);
-//! let signers = aggregator.get_signers();
+//! let signers = aggregator.signers();
 //! # Ok(()) }
 //! # fn main() { assert!(do_test().is_ok()); }
 //! ```
@@ -1530,7 +1530,7 @@
 //! # aggregator.include_signer(1, alice_public_comshares.commitments[0], &alice_public_key);
 //! # aggregator.include_signer(3, carol_public_comshares.commitments[0], &carol_public_key);
 //! #
-//! # let signers = aggregator.get_signers();
+//! # let signers = aggregator.signers();
 //! # let message_hash = Secp256k1Sha256::h4(&message[..]);
 //!
 //! let alice_partial = alice_secret_key.sign(

--- a/src/sign/signature.rs
+++ b/src/sign/signature.rs
@@ -750,7 +750,7 @@ mod test {
                 &group_key,
                 &mut p1_secret_comshares,
                 0,
-                &aggregator.signers(),
+                aggregator.signers(),
             )
             .unwrap();
 
@@ -792,7 +792,7 @@ mod test {
                 &group_key,
                 &mut p1_secret_comshares,
                 0,
-                &aggregator.signers(),
+                aggregator.signers(),
             )
             .unwrap();
 
@@ -830,7 +830,7 @@ mod test {
                 &group_key,
                 &mut p1_secret_comshares,
                 0,
-                &aggregator.signers(),
+                aggregator.signers(),
             )
             .unwrap();
 
@@ -880,7 +880,7 @@ mod test {
                 &group_key,
                 &mut p1_secret_comshares,
                 0,
-                &aggregator.signers(),
+                aggregator.signers(),
             )
             .unwrap();
         let p3_partial = p3_sk
@@ -889,7 +889,7 @@ mod test {
                 &group_key,
                 &mut p3_secret_comshares,
                 0,
-                &aggregator.signers(),
+                aggregator.signers(),
             )
             .unwrap();
         let p4_partial = p4_sk
@@ -898,7 +898,7 @@ mod test {
                 &group_key,
                 &mut p4_secret_comshares,
                 0,
-                &aggregator.signers(),
+                aggregator.signers(),
             )
             .unwrap();
 
@@ -944,7 +944,7 @@ mod test {
                 &group_key,
                 &mut p1_secret_comshares,
                 0,
-                &aggregator.signers(),
+                aggregator.signers(),
             )
             .unwrap();
         let p2_partial = p2_sk
@@ -953,7 +953,7 @@ mod test {
                 &group_key,
                 &mut p2_secret_comshares,
                 0,
-                &aggregator.signers(),
+                aggregator.signers(),
             )
             .unwrap();
 
@@ -1005,7 +1005,7 @@ mod test {
                     &group_key,
                     &mut d1_secret_comshares,
                     0,
-                    &aggregator.signers(),
+                    aggregator.signers(),
                 )
                 .unwrap();
             let d2_partial = d2_sk
@@ -1014,7 +1014,7 @@ mod test {
                     &group_key,
                     &mut d2_secret_comshares,
                     0,
-                    &aggregator.signers(),
+                    aggregator.signers(),
                 )
                 .unwrap();
 
@@ -1054,7 +1054,7 @@ mod test {
                     &group_key,
                     &mut s1_secret_comshares,
                     0,
-                    &aggregator.signers(),
+                    aggregator.signers(),
                 )
                 .unwrap();
             let s2_partial = s2_sk
@@ -1063,7 +1063,7 @@ mod test {
                     &group_key,
                     &mut s2_secret_comshares,
                     0,
-                    &aggregator.signers(),
+                    aggregator.signers(),
                 )
                 .unwrap();
 
@@ -1124,7 +1124,7 @@ mod test {
                     &group_key,
                     &mut d1_secret_comshares,
                     0,
-                    &aggregator.signers(),
+                    aggregator.signers(),
                 )
                 .unwrap();
             let d2_partial = d2_sk
@@ -1133,7 +1133,7 @@ mod test {
                     &group_key,
                     &mut d2_secret_comshares,
                     0,
-                    &aggregator.signers(),
+                    aggregator.signers(),
                 )
                 .unwrap();
 
@@ -1178,7 +1178,7 @@ mod test {
                     &group_key,
                     &mut s1_secret_comshares,
                     0,
-                    &aggregator.signers(),
+                    aggregator.signers(),
                 )
                 .unwrap();
             let s2_partial = s2_sk
@@ -1187,7 +1187,7 @@ mod test {
                     &group_key,
                     &mut s2_secret_comshares,
                     0,
-                    &aggregator.signers(),
+                    aggregator.signers(),
                 )
                 .unwrap();
             let s3_partial = s3_sk
@@ -1196,7 +1196,7 @@ mod test {
                     &group_key,
                     &mut s3_secret_comshares,
                     0,
-                    &aggregator.signers(),
+                    aggregator.signers(),
                 )
                 .unwrap();
 
@@ -1547,7 +1547,7 @@ mod test {
                 &group_key,
                 &mut p2_secret_comshares,
                 0,
-                &aggregator.signers(),
+                aggregator.signers(),
             )
             .unwrap();
         let p3_partial = p3_secret_key
@@ -1556,7 +1556,7 @@ mod test {
                 &group_key,
                 &mut p3_secret_comshares,
                 0,
-                &aggregator.signers(),
+                aggregator.signers(),
             )
             .unwrap();
         let p5_partial = p5_secret_key
@@ -1565,7 +1565,7 @@ mod test {
                 &group_key,
                 &mut p5_secret_comshares,
                 0,
-                &aggregator.signers(),
+                aggregator.signers(),
             )
             .unwrap();
 
@@ -1612,7 +1612,7 @@ mod test {
                 &group_key,
                 &mut p1_secret_comshares,
                 0,
-                &aggregator.signers(),
+                aggregator.signers(),
             )
             .unwrap();
         let p2_partial = p2_sk
@@ -1621,7 +1621,7 @@ mod test {
                 &group_key,
                 &mut p2_secret_comshares,
                 0,
-                &aggregator.signers(),
+                aggregator.signers(),
             )
             .unwrap();
 

--- a/tests/ice_frost.rs
+++ b/tests/ice_frost.rs
@@ -225,11 +225,16 @@ fn signing_and_verification_3_out_of_5() {
 
     let mut aggregator = SignatureAggregator::new(params, group_key, &message[..]);
 
-    aggregator.include_signer(1, p1_public_comshares.commitments[0], &p1_sk.to_public());
-    aggregator.include_signer(3, p3_public_comshares.commitments[0], &p3_sk.to_public());
-    aggregator.include_signer(4, p4_public_comshares.commitments[0], &p4_sk.to_public());
+    aggregator
+        .include_signer(1, p1_public_comshares.commitments[0], &p1_sk.to_public())
+        .unwrap();
+    aggregator
+        .include_signer(3, p3_public_comshares.commitments[0], &p3_sk.to_public())
+        .unwrap();
+    aggregator
+        .include_signer(4, p4_public_comshares.commitments[0], &p4_sk.to_public())
+        .unwrap();
 
-    aggregator.dedup_signers().unwrap();
     let message_hash = Secp256k1Sha256::h4(&message[..]);
     let signers = aggregator.signers();
     let p1_partial = p1_sk

--- a/tests/ice_frost.rs
+++ b/tests/ice_frost.rs
@@ -229,9 +229,9 @@ fn signing_and_verification_3_out_of_5() {
     aggregator.include_signer(3, p3_public_comshares.commitments[0], &p3_sk.to_public());
     aggregator.include_signer(4, p4_public_comshares.commitments[0], &p4_sk.to_public());
 
-    let signers = aggregator.get_signers();
+    aggregator.dedup_signers().unwrap();
     let message_hash = Secp256k1Sha256::h4(&message[..]);
-
+    let signers = aggregator.signers();
     let p1_partial = p1_sk
         .sign(
             &message_hash,


### PR DESCRIPTION
The `get_signers()` method has side effects, which is a bit of a code smell. The deduplication
and sanity checks should not run as part of a getter. The naming is not idiomatic in rust, where
`get_` prefixes are considered redundant. Finally, the deduplication method crashes the process
if the dedup'd number of signers falls below the threshold, which is annoying to users of the 
library.

~~Ideally the refactoring should continue one more step and run the deduplication&checks every
time a Signer is added, but that is future work.~~

This PR also makes the `signers` a private member, and enforces sorting&deduplication in the setter, guaranteeing a valid list of signers at all times.

