### PR TITLE
Don't set the `js` feature for `getrandom`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ ark-ff = { version = "0.4", default-features = false }
 ark-ec = { version = "0.4", default-features = false }
 ark-serialize = { version = "0.4", default-features = false, features = ["derive"] }
 digest = { version = "0.10", default-features = false, features = ["alloc"] }
-getrandom = { version = "0.2", default-features = false, features = ["js"] }
+getrandom = { version = "0.2", default-features = false }
 rand = { version = "0.8", default-features = false, features = ["alloc", "getrandom", "libc"] }
 sha2 = { version = "0.10", default-features = false }
 aes-gcm = { version = "0.10", default-features = false, features = ["aes", "alloc", "getrandom", "zeroize"] }
@@ -32,7 +32,7 @@ hkdf = { version = "0.12", default-features = false }
 zeroize = { version = "1", default-features = false, features = ["alloc", "zeroize_derive"] }
 
 [dev-dependencies]
-criterion = { version = "0.3" }
+criterion = { version = "0.5" }
 
 [[bench]]
 name = "dkg"


### PR DESCRIPTION
Libraries should avoid setting features that may or may not be required when used.

The getrandom docs put it better: "This feature should only be enabled for binary, test, or benchmark crates. Library crates should generally not enable this feature, leaving such a decision to users of their library. Also, libraries should not introduce their own js features just to enable getrandom’s js feature."
